### PR TITLE
ppo Adam eps to match Andrychowicz, et al. (2021)

### DIFF
--- a/ppo/ppo.py
+++ b/ppo/ppo.py
@@ -127,7 +127,7 @@ class PPO(Algorithm):
 
         self.gamma = gamma
         self.gae_lambda = gae_lambda
-        self.optimizer = Adam(self.policy.parameters(), lr=learning_rate)
+        self.optimizer = Adam(self.policy.parameters(), lr=learning_rate, eps=1e-7)
         self.lr_schedule = (
             linear_schedule(learning_rate, 0)
             if learning_rate_decay == "linear"


### PR DESCRIPTION
Report: [2/15/2023 ppo_eps_1e-7 Lambda Benchmark](https://api.wandb.ai/links/sgoodfriend/osbhv0u3)
Control: [2/8/2023 PPO Tweaks Lambda Benchmark](https://api.wandb.ai/links/sgoodfriend/448odm37?_gl=1*1g3arhk*_ga*MTQ1ODc0MjA1LjE2NzEyMjY5ODA.*_ga_JH1SJHJQXJ*MTY3NjU2OTU3Mi4xNDkuMS4xNjc2NTcyMzcxLjU1LjAuMA..)

Comparison against control shows little consistent change. Some are higher and some lower (the best gains are in the PyBullet environments, while the biggest loser is CarRacing-v0). Removing CarRacing-v0 and Walker2DBulletEnv-v0 (the biggest gainer) has the rest of the stats looking like a wash.

**Total Score: 0.75**
|      | algo   | env                         | control               | expierment            |      score |   best_eval_mean_mean |   best_eval_mean_median |   best_eval_result_mean |   best_eval_result_median |   eval_mean_mean |   eval_mean_median |   eval_result_mean |   eval_result_median |
|:-----|:-------|:----------------------------|:----------------------|:----------------------|-----------:|----------------------:|------------------------:|------------------------:|--------------------------:|-----------------:|-------------------:|-------------------:|---------------------:|
| 0    | ppo    | MountainCar-v0              | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  0.75      |              3.44     |                -2.08    |                7.4      |                   0.59    |         5.14     |               4.46 |               9.22 |                10.99 |
| 1    | ppo    | CartPole-v1                 | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  0.25      |              0        |                 0       |                0        |                   0       |         1.98     |               0    |               4.68 |                 0    |
| 2    | ppo    | MountainCarContinuous-v0    | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} | -1         |             -0.03     |                -0.07    |               -0.06     |                  -0.1     |        -1.01     |              -1.01 |              -1.12 |                -1.01 |
| 3    | ppo    | Acrobot-v1                  | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} | -0.5       |             -3.7      |                -0.99    |               -1.79     |                  -0.48    |        -3.7      |               2.38 |             -11.47 |                 3.35 |
| 4    | ppo    | LunarLander-v2              | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} | -1         |             -7.26     |                -3.56    |               -7.72     |                  -4.61    |        -7.95     |              -5.93 |              -8.56 |                -6.64 |
| 5    | ppo    | HalfCheetahBulletEnv-v0     | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  0.25      |              0.29     |                 0.88    |               -0.65     |                  -0.98    |         0.65     |               2.73 |              -0.26 |                 1.47 |
| 6    | ppo    | AntBulletEnv-v0             | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  1         |              4.75     |                 2.2     |                4.77     |                   1.67    |         4.5      |               1.99 |               5.69 |                 2.09 |
| 7    | ppo    | HopperBulletEnv-v0          | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  0.75      |              3.73     |                 7.61    |                4.73     |                   7.01    |         5.72     |               3.6  |               6.58 |                -1.16 |
| 8    | ppo    | Walker2DBulletEnv-v0        | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  1         |             24.21     |                11.31    |               24.44     |                  12.32    |        25.16     |               9.49 |              37.93 |                16.91 |
| 9    | ppo    | CarRacing-v0                | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} | -1         |            -22.45     |               -28.28    |              -44.46     |                 -52.59    |       -33        |             -34.39 |             -59.36 |               -61.09 |
| 10   | ppo    | PongNoFrameskip-v4          | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  0.5       |              0.1      |                 0       |                0.24     |                   0       |         0.2      |               0.6  |              -0.02 |                 2.02 |
| 11   | ppo    | BreakoutNoFrameskip-v4      | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} | -1         |             -2.45     |                -4.85    |               -5.56     |                  -6.57    |        -5.06     |              -5.43 |             -17.17 |               -25    |
| 12   | ppo    | SpaceInvadersNoFrameskip-v4 | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  0         |             -0.42     |                -1.28    |                7.92     |                   5.32    |        -3.71     |              -5.68 |               6.36 |                11.66 |
| 13   | ppo    | QbertNoFrameskip-v4         | {'benchmark_fbc943f'} | {'benchmark_f59bf74'} |  0.75      |              4.01     |                 3.95    |                2.81     |                  -3.73    |         1.02     |               0.45 |               0.06 |                 8.19 |
| mean | nan    | nan                         | nan                   | nan                   |  0.0535714 |              0.301429 |                -1.08286 |               -0.566429 |                  -3.01071 |        -0.718571 |              -1.91 |              -1.96 |                -2.73 |