### PR TITLE
Use SB3's VecEnv while using custom gym-like normalization

### DIFF
--- a/rl_algo_impls/runner/config.py
+++ b/rl_algo_impls/runner/config.py
@@ -50,7 +50,7 @@ class EnvHyperparams:
     video_step_interval: Union[int, float] = 1_000_000
     initial_steps_to_truncate: Optional[int] = None
     clip_atari_rewards: bool = True
-    normalize_type: Optional[str] = None
+    normalize_type: Optional[str] = "gymlike"
 
 
 HyperparamsSelf = TypeVar("HyperparamsSelf", bound="Hyperparams")

--- a/rl_algo_impls/runner/config.py
+++ b/rl_algo_impls/runner/config.py
@@ -36,7 +36,7 @@ class RunArgs:
 
 @dataclass
 class EnvHyperparams:
-    env_type: str = "gymvec"
+    env_type: str = "sb3vec"
     n_envs: int = 1
     frame_stack: int = 1
     make_kwargs: Optional[Dict[str, Any]] = None
@@ -50,6 +50,7 @@ class EnvHyperparams:
     video_step_interval: Union[int, float] = 1_000_000
     initial_steps_to_truncate: Optional[int] = None
     clip_atari_rewards: bool = True
+    normalize_type: Optional[str] = "gymlike"
 
 
 HyperparamsSelf = TypeVar("HyperparamsSelf", bound="Hyperparams")

--- a/rl_algo_impls/runner/config.py
+++ b/rl_algo_impls/runner/config.py
@@ -50,7 +50,7 @@ class EnvHyperparams:
     video_step_interval: Union[int, float] = 1_000_000
     initial_steps_to_truncate: Optional[int] = None
     clip_atari_rewards: bool = True
-    normalize_type: Optional[str] = "gymlike"
+    normalize_type: Optional[str] = None
 
 
 HyperparamsSelf = TypeVar("HyperparamsSelf", bound="Hyperparams")


### PR DESCRIPTION
Same performance using gym-like normalization versus SB3's VecNormalize: https://api.wandb.ai/links/sgoodfriend/02azp2vp

The advantage of gym-like normalization is that it's saving mechanism doesn't run afoul of Huggingface's restrictions on pickle files.