### PR TITLE
Turn off ppo2_vf_coef_halving by default

### DIFF
--- a/rl_algo_impls/ppo/ppo.py
+++ b/rl_algo_impls/ppo/ppo.py
@@ -103,7 +103,7 @@ class PPO(Algorithm):
         ent_coef: float = 0.0,
         ent_coef_decay: str = "none",
         vf_coef: float = 0.5,
-        ppo2_vf_coef_halving: bool = True,
+        ppo2_vf_coef_halving: bool = False,
         max_grad_norm: float = 0.5,
         sde_sample_freq: int = -1,
     ) -> None:


### PR DESCRIPTION
https://wandb.ai/sgoodfriend/rl-algo-impls-benchmarks/reports/v0-0-7-PPO-tweaks-benchmark--VmlldzozODczOTMz

**Total Score: 3.3200000000000003**
|      | algo   | env                         | control               | expierment            |     score |   best_eval/mean_mean |   best_eval/mean_median |   best_eval/result_mean |   best_eval/result_median |   eval/mean_mean |   eval/mean_median |   eval/result_mean |   eval/result_median |   train_rolling/mean_mean |   train_rolling/mean_median |   train_rolling/result_mean |   train_rolling/result_median |
|:-----|:-------|:----------------------------|:----------------------|:----------------------|----------:|----------------------:|------------------------:|------------------------:|--------------------------:|-----------------:|-------------------:|-------------------:|---------------------:|--------------------------:|----------------------------:|----------------------------:|------------------------------:|
| 0    | ppo    | CartPole-v1                 | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  0.33     |               0       |                 0       |                 0       |                    0      |            0     |            0       |            0       |                0     |                   1.83    |                       0.99  |                    10.26    |                         7.29  |
| 1    | ppo    | MountainCar-v0              | {'benchmark_98dc855'} | {'benchmark_aa026b7'} | -0.17     |              -3.49    |                -4.54    |                -0.04    |                   -1.18   |            1.76  |            2.92    |           -4.67    |               -2.07  |                   2.57    |                       5.23  |                     1.73    |                        -0.4   |
| 2    | ppo    | Acrobot-v1                  | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  1        |               1.1     |                 1.76    |                 0.39    |                    0.86   |            2.64  |            6.24    |            6.13    |                5.04  |                   1.99    |                       2.97  |                     2.6     |                         0.22  |
| 3    | ppo    | LunarLander-v2              | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  1        |               3.86    |                 3.08    |                 4.19    |                    5.08   |            3.95  |            4.88    |            6.87    |                5.84  |                   3.61    |                       3.07  |                     8.78    |                         2.5   |
| 4    | ppo    | PongNoFrameskip-v4          | {'benchmark_98dc855'} | {'benchmark_aa026b7'} | -1        |              -0.6     |                -0.6     |                -1.19    |                   -1.32   |           -1.71  |           -1.2     |           -3.53    |               -1.64  |                  -0.77    |                      -0.72  |                    -2.26    |                        -2.3   |
| 5    | ppo    | BreakoutNoFrameskip-v4      | {'benchmark_98dc855'} | {'benchmark_aa026b7'} | -0.33     |              -3.97    |                -0.06    |                -5.5     |                   -0.97   |           -1.47  |           -3.48    |          -10.18    |              -13.03  |                   0.3     |                       5.53  |                     0.97    |                         9.87  |
| 6    | ppo    | SpaceInvadersNoFrameskip-v4 | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  0.33     |               2.51    |                13.88    |                 4.08    |                   29.86   |           -4.29  |           -4.93    |          -20.23    |              -13.98  |                  10.68    |                      14.05  |                    15.11    |                        29.07  |
| 7    | ppo    | QbertNoFrameskip-v4         | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  0.5      |               2.07    |                 0.84    |                -0.19    |                   -1.04   |            0.63  |            0.94    |            1.58    |                1.06  |                   3.35    |                       2.62  |                     2.69    |                        -1.65  |
| 8    | ppo    | MountainCarContinuous-v0    | {'benchmark_98dc855'} | {'benchmark_aa026b7'} | -0.67     |              -0.07    |                -0.05    |                -0.04    |                    0.03   |           -0.51  |           -0.83    |           -0.71    |               -1.07  |                  -4.67    |                      -0.13  |                   -16.65    |                         0.13  |
| 9    | ppo    | BipedalWalker-v3            | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  0        |               1.25    |                -0.04    |                 1.23    |                   -0.02   |           -7.25  |           -6.6     |          -27.62    |              -35.1   |                   1.1     |                       1.92  |                     2.1     |                         0.19  |
| 10   | ppo    | HalfCheetahBulletEnv-v0     | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  1        |              22.63    |                32.19    |                23.45    |                   33.14   |           17.45  |           17.63    |            6.76    |               13.29  |                  18.93    |                      25.89  |                    17.89    |                        14.43  |
| 11   | ppo    | AntBulletEnv-v0             | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  1        |               0.55    |                 5.07    |                 0.88    |                    6.23   |            1.19  |            5.07    |            0.06    |                6.23  |                   0.72    |                       4.12  |                     1.98    |                         5.32  |
| 12   | ppo    | HopperBulletEnv-v0          | {'benchmark_98dc855'} | {'benchmark_aa026b7'} | -0.17     |               0.51    |                 7.89    |                 0.81    |                    7.64   |           -2.49  |            3.22    |           -8.66    |              -11.21  |                 -11.17    |                     -18.84  |                   -25.09    |                       -40.95  |
| 13   | ppo    | Walker2DBulletEnv-v0        | {'benchmark_98dc855'} | {'benchmark_aa026b7'} |  0.83     |              22       |                78.13    |                20.85    |                   76.22   |           12.61  |           58.57    |           -8.89    |                6.67  |                  21.21    |                      86.72  |                     3.41    |                        48.41  |
| 14   | ppo    | CarRacing-v0                | {'benchmark_98dc855'} | {'benchmark_aa026b7'} | -0.33     |               4.55    |                11.78    |                 3.95    |                   14.66   |           -5.2   |          -13.59    |          -13.51    |              -18.65  |                  -0.34    |                      -0.85  |                    -0.1     |                        -0.49  |
| mean | nan    | nan                         | nan                   | nan                   |  0.221333 |               3.52667 |                 9.95533 |                 3.52467 |                   11.2793 |            1.154 |            4.58933 |           -5.10667 |               -3.908 |                   3.28933 |                       8.838 |                     1.56133 |                         4.776 |