### PR TITLE
Default update_advantage_between_epochs True

### DIFF
--- a/rl_algo_impls/ppo/ppo.py
+++ b/rl_algo_impls/ppo/ppo.py
@@ -106,7 +106,7 @@ class PPO(Algorithm):
         ppo2_vf_coef_halving: bool = True,
         max_grad_norm: float = 0.5,
         sde_sample_freq: int = -1,
-        update_advantage_between_epochs: bool = False,
+        update_advantage_between_epochs: bool = True,
         update_returns_between_epochs: bool = False,
     ) -> None:
         super().__init__(policy, env, device, tb_writer)


### PR DESCRIPTION
This undoes the change at https://github.com/sgoodfriend/rl-algo-impls/pull/16/files#diff-90c3bbc9dcbdef33c8ef5132268a71f1bb355143c4043e1eb91463fb1a0cd387L247

https://api.wandb.ai/links/sgoodfriend/e7vzv191

**Total Score: 2.26**
|      | algo   | env                         | control               | expierment            |     score |   best_eval/mean_mean |   best_eval/mean_median |   best_eval/result_mean |   best_eval/result_median |   eval/mean_mean |   eval/mean_median |   eval/result_mean |   eval/result_median |   train_rolling/mean_mean |   train_rolling/mean_median |   train_rolling/result_mean |   train_rolling/result_median |
|:-----|:-------|:----------------------------|:----------------------|:----------------------|----------:|----------------------:|------------------------:|------------------------:|--------------------------:|-----------------:|-------------------:|-------------------:|---------------------:|--------------------------:|----------------------------:|----------------------------:|------------------------------:|
| 0    | ppo    | CartPole-v1                 | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  0.33     |               0       |                   0     |                 0       |                     0     |             0    |            0       |            0       |              0       |                     1.83  |                     0.99    |                    10.26    |                         7.29  |
| 1    | ppo    | MountainCar-v0              | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  0.5      |              -2.25    |                  -5.2   |                 3.64    |                     2.45  |             1.07 |           -2       |            3.23    |              7.01    |                     2.84  |                     6.23    |                     1.61    |                         0.61  |
| 2    | ppo    | Acrobot-v1                  | {'benchmark_98dc855'} | {'benchmark_22bde9f'} | -0.5      |               0.15    |                  -0.28  |                -0.53    |                     0.38  |            -3.57 |           -3.83    |           -9.86    |             -9.39    |                    -0.83  |                    -2.61    |                     3.59    |                        -6.58  |
| 3    | ppo    | LunarLander-v2              | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  1        |               2.29    |                   2.59  |                 3.2     |                     5.03  |             4.13 |            5.6     |            6.74    |              5.72    |                     3.25  |                     1.65    |                     9.2     |                         3.77  |
| 4    | ppo    | PongNoFrameskip-v4          | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  0.42     |               0       |                   0.3   |                 0.25    |                     1.47  |             0.1  |           -0.6     |           -0.39    |             -0.89    |                     0.27  |                     0.29    |                     0.17    |                         0.43  |
| 5    | ppo    | BreakoutNoFrameskip-v4      | {'benchmark_98dc855'} | {'benchmark_22bde9f'} | -0.5      |              -0.98    |                  -0.25  |                -1.71    |                    -1.89  |            -1.75 |           -5.14    |           -9.19    |            -13.03    |                     3.27  |                    10.83    |                    -4.78    |                         2.09  |
| 6    | ppo    | SpaceInvadersNoFrameskip-v4 | {'benchmark_98dc855'} | {'benchmark_22bde9f'} | -0.33     |              -6.53    |                   5.76  |               -10.02    |                    15.34  |            -4.03 |          -15.71    |          -13.99    |            -12.5     |                    -3.3   |                     4.13    |                    -7.57    |                         0.89  |
| 7    | ppo    | QbertNoFrameskip-v4         | {'benchmark_98dc855'} | {'benchmark_22bde9f'} | -0.33     |               0.31    |                   0.25  |                -2.9     |                    -2.36  |            -3.73 |            3.54    |           -3.72    |             12.65    |                    -3.93  |                    -4.51    |                    -1.71    |                        -5.41  |
| 8    | ppo    | MountainCarContinuous-v0    | {'benchmark_98dc855'} | {'benchmark_22bde9f'} | -0.33     |              -0.01    |                   0.08  |                -0.01    |                     0.15  |            -0.43 |           -0.49    |           -0.54    |             -0.71    |                    -0.86  |                     0.83    |                    -5.81    |                         1.22  |
| 9    | ppo    | BipedalWalker-v3            | {'benchmark_98dc855'} | {'benchmark_22bde9f'} | -0.67     |              -0.03    |                  -1.52  |                -0.01    |                    -1.57  |           -15.85 |           -8.18    |          -49.5     |            -39.58    |                    -3.24  |                     0.88    |                    -5.79    |                         3.99  |
| 10   | ppo    | HalfCheetahBulletEnv-v0     | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  1        |               9.81    |                  16.64  |                 9.77    |                    16.71  |             8.28 |           14.36    |            8.76    |             14.96    |                     8.05  |                    13.62    |                    10.95    |                        15.91  |
| 11   | ppo    | AntBulletEnv-v0             | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  0.67     |               2.64    |                   9.37  |                 2.42    |                    10.09  |             2.54 |            7.13    |           -2.03    |             -1.59    |                     4.03  |                     6.59    |                     5.22    |                         6.77  |
| 12   | ppo    | HopperBulletEnv-v0          | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  0.67     |               9.14    |                  14.59  |                 9.52    |                    14.24  |            10.45 |           14.08    |           17.52    |             13.29    |                     0.95  |                     4.23    |                   -12.61    |                       -20.32  |
| 13   | ppo    | Walker2DBulletEnv-v0        | {'benchmark_98dc855'} | {'benchmark_22bde9f'} |  1        |              41.4     |                  94.68  |                41.27    |                    93.77  |            42.08 |           97.01    |           43.8     |            105.63    |                    62.87  |                   111.77    |                    92.82    |                       127.91  |
| 14   | ppo    | CarRacing-v0                | {'benchmark_98dc855'} | {'benchmark_22bde9f'} | -0.67     |               5.9     |                  -0.93  |                 4.74    |                    -6.18  |            -6.59 |          -29.77    |          -12.21    |            -38.66    |                    -3.56  |                   -14.9     |                   -11.98    |                       -27.69  |
| mean | nan    | nan                         | nan                   | nan                   |  0.150667 |               4.12267 |                   9.072 |                 3.97533 |                     9.842 |             2.18 |            5.06667 |           -1.42533 |              2.86067 |                     4.776 |                     9.33467 |                     5.57133 |                         7.392 |