### PR TITLE
Actor-critic Behavior Cloning

### DIFF
--- a/rl_algo_impls/a2c/a2c.py
+++ b/rl_algo_impls/a2c/a2c.py
@@ -10,7 +10,7 @@ from torch.utils.tensorboard.writer import SummaryWriter
 
 from rl_algo_impls.shared.algorithm import Algorithm
 from rl_algo_impls.shared.callbacks import Callback
-from rl_algo_impls.shared.gae import compute_advantages
+from rl_algo_impls.shared.gae import compute_advantages_from_policy
 from rl_algo_impls.shared.policy.actor_critic import ActorCritic
 from rl_algo_impls.shared.schedule import schedule, update_learning_rate
 from rl_algo_impls.shared.stats import log_scalars
@@ -127,7 +127,7 @@ class A2C(Algorithm):
                     clamped_action
                 )
 
-            advantages = compute_advantages(
+            advantages = compute_advantages_from_policy(
                 rewards,
                 values,
                 episode_starts,

--- a/rl_algo_impls/acbc/acbc.py
+++ b/rl_algo_impls/acbc/acbc.py
@@ -149,32 +149,30 @@ class ACBC(Algorithm):
                 if self.gradient_accumulation:
                     self.optimizer_step(optimizer)
 
-                var_y = np.var(r.y_true).item()
-                explained_var = (
-                    np.nan
-                    if var_y == 0
-                    else 1 - np.var(r.y_true - r.y_pred).item() / var_y
-                )
-                TrainStats(step_stats, explained_var).write_to_tensorboard(
-                    self.tb_writer, timesteps_elapsed
-                )
+            var_y = np.var(r.y_true).item()
+            explained_var = (
+                np.nan if var_y == 0 else 1 - np.var(r.y_true - r.y_pred).item() / var_y
+            )
+            TrainStats(step_stats, explained_var).write_to_tensorboard(
+                self.tb_writer, timesteps_elapsed
+            )
 
-                end_time = perf_counter()
-                rollout_steps = r.total_steps
-                self.tb_writer.add_scalar(
-                    "train/steps_per_second",
-                    rollout_steps / (end_time - start_time),
-                    timesteps_elapsed,
-                )
+            end_time = perf_counter()
+            rollout_steps = r.total_steps
+            self.tb_writer.add_scalar(
+                "train/steps_per_second",
+                rollout_steps / (end_time - start_time),
+                timesteps_elapsed,
+            )
 
-                if callbacks:
-                    if not all(
-                        c.on_step(timesteps_elapsed=rollout_steps) for c in callbacks
-                    ):
-                        logging.info(
-                            f"Callback terminated training at {timesteps_elapsed} timesteps"
-                        )
-                        break
+            if callbacks:
+                if not all(
+                    c.on_step(timesteps_elapsed=rollout_steps) for c in callbacks
+                ):
+                    logging.info(
+                        f"Callback terminated training at {timesteps_elapsed} timesteps"
+                    )
+                    break
         return self
 
     def optimizer_step(self, optimizer: Optimizer) -> None:

--- a/rl_algo_impls/acbc/acbc.py
+++ b/rl_algo_impls/acbc/acbc.py
@@ -109,6 +109,7 @@ class ACBC(Algorithm):
                         mb_logprobs,
                         mb_actions,
                         mb_action_masks,
+                        mb_num_actions,
                         _,
                         _,
                         mb_returns,
@@ -118,10 +119,8 @@ class ACBC(Algorithm):
                         mb_obs, mb_actions, action_masks=mb_action_masks
                     )
                     if self.scale_loss_by_num_actions:
-                        with torch.no_grad():
-                            num_actions = mb_action_masks.any(2).sum(1)
                         pi_loss = -torch.where(
-                            num_actions > 0, new_logprobs / num_actions, 0
+                            mb_num_actions > 0, new_logprobs / mb_num_actions, 0
                         ).mean()
                     else:
                         pi_loss = -new_logprobs.mean()

--- a/rl_algo_impls/acbc/acbc.py
+++ b/rl_algo_impls/acbc/acbc.py
@@ -1,0 +1,175 @@
+import logging
+from dataclasses import astuple
+from time import perf_counter
+from typing import Dict, List, Optional, TypeVar
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.optim import Adam, Optimizer
+from torch.utils.tensorboard.writer import SummaryWriter
+
+from rl_algo_impls.acbc.train_stats import TrainStats
+from rl_algo_impls.ppo.rollout import RolloutGenerator
+from rl_algo_impls.shared.algorithm import Algorithm
+from rl_algo_impls.shared.callbacks.callback import Callback
+from rl_algo_impls.shared.policy.actor_critic import ActorCritic
+from rl_algo_impls.shared.schedule import schedule, update_learning_rate
+from rl_algo_impls.shared.stats import log_scalars
+
+"""
+Actor-Critic Behavior Cloning with Critic Bootstrapping
+"""
+
+ACBCSelf = TypeVar("ACBCSelf", bound="ACBC")
+
+
+class ACBC(Algorithm):
+    def __init__(
+        self,
+        policy: ActorCritic,
+        device: torch.device,
+        tb_writer: SummaryWriter,
+        learning_rate: float = 3e-4,
+        learning_rate_decay: str = "none",
+        batch_size: int = 64,
+        n_epochs: int = 10,
+        gamma: float = 0.99,
+        gae_lambda: float = 0.95,
+        vf_coef: float = 0.25,
+        max_grad_norm: float = 0.5,
+        update_returns_between_epochs: bool = False,
+        gradient_accumulation: bool = False,
+    ) -> None:
+        super().__init__(policy, device, tb_writer)
+        self.policy = policy
+
+        self.learning_rate_schedule = schedule(learning_rate_decay, learning_rate)
+        self.batch_size = batch_size
+        self.n_epochs = n_epochs
+        self.gamma = gamma
+        self.gae_lambda = gae_lambda
+        self.vf_coef = vf_coef
+        self.max_grad_norm = max_grad_norm
+        self.update_returns_between_epochs = update_returns_between_epochs
+        self.gradient_accumulation = gradient_accumulation
+
+    def learn(
+        self: ACBCSelf,
+        train_timesteps: int,
+        rollout_generator: RolloutGenerator,
+        callbacks: Optional[List[Callback]] = None,
+        total_timesteps: Optional[int] = None,
+        start_timesteps: int = 0,
+    ) -> ACBCSelf:
+        if total_timesteps is None:
+            total_timesteps = train_timesteps
+        assert start_timesteps + train_timesteps <= total_timesteps
+        timesteps_elapsed = start_timesteps
+
+        optimizer = None
+
+        while timesteps_elapsed < start_timesteps + train_timesteps:
+            start_time = perf_counter()
+
+            progress = timesteps_elapsed / total_timesteps
+            learning_rate = self.learning_rate_schedule(progress)
+            if not optimizer:
+                optimizer = Adam(self.policy.parameters(), lr=learning_rate)
+            else:
+                update_learning_rate(optimizer, learning_rate)
+
+            chart_scalars = {
+                "learning_rate": optimizer.param_groups[0]["lr"],
+            }
+            log_scalars(self.tb_writer, "charts", chart_scalars, timesteps_elapsed)
+
+            r = rollout_generator.rollout()
+            timesteps_elapsed += r.total_steps
+
+            step_stats: List[Dict[str, float]] = []
+            for e in range(self.n_epochs):
+                if e == 0 or self.update_returns_between_epochs:
+                    # Using the same value head computation as PPO since the idea is
+                    # that the BC model will be the starting point for PPO.
+                    r.update_advantages(
+                        self.policy,
+                        self.gamma,
+                        self.gae_lambda,
+                        update_returns=self.update_returns_between_epochs,
+                    )
+                step_stats.clear()
+                for mb in r.minibatches(self.batch_size, self.device):
+                    self.policy.reset_noise(self.batch_size)
+
+                    (
+                        mb_obs,
+                        mb_logprobs,
+                        mb_actions,
+                        mb_action_masks,
+                        _,
+                        _,
+                        mb_returns,
+                    ) = astuple(mb)
+
+                    new_logprobs, _, new_values = self.policy(
+                        mb_obs, mb_actions, action_masks=mb_action_masks
+                    )
+
+                    pi_loss = -new_logprobs.mean()
+                    v_loss = ((new_values - mb_returns) ** 2).mean(0)
+                    loss = pi_loss + self.vf_coef * v_loss
+
+                    if self.gradient_accumulation:
+                        loss /= r.num_minibatches(self.batch_size)
+                    loss.backward()
+                    if not self.gradient_accumulation:
+                        self.optimizer_step(optimizer)
+
+                    with torch.no_grad():
+                        logratio = new_logprobs - mb_logprobs
+                        ratio = torch.exp(logratio)
+                        approx_kl = ((ratio - 1) - logratio).mean().cpu().numpy().item()
+                        step_stats.append(
+                            {
+                                "loss": loss.item(),
+                                "pi_loss": pi_loss.item(),
+                                "v_loss": v_loss.item(),
+                                "approx_kl": approx_kl,
+                            }
+                        )
+                if self.gradient_accumulation:
+                    self.optimizer_step(optimizer)
+
+                var_y = np.var(r.y_true).item()
+                explained_var = (
+                    np.nan
+                    if var_y == 0
+                    else 1 - np.var(r.y_true - r.y_pred).item() / var_y
+                )
+                TrainStats(step_stats, explained_var).write_to_tensorboard(
+                    self.tb_writer, timesteps_elapsed
+                )
+
+                end_time = perf_counter()
+                rollout_steps = r.total_steps
+                self.tb_writer.add_scalar(
+                    "train/steps_per_second",
+                    rollout_steps / (end_time - start_time),
+                    timesteps_elapsed,
+                )
+
+                if callbacks:
+                    if not all(
+                        c.on_step(timesteps_elapsed=rollout_steps) for c in callbacks
+                    ):
+                        logging.info(
+                            f"Callback terminated training at {timesteps_elapsed} timesteps"
+                        )
+                        break
+        return self
+
+    def optimizer_step(self, optimizer: Optimizer) -> None:
+        nn.utils.clip_grad_norm_(self.policy.parameters(), self.max_grad_norm)
+        optimizer.step()
+        optimizer.zero_grad()

--- a/rl_algo_impls/acbc/train_stats.py
+++ b/rl_algo_impls/acbc/train_stats.py
@@ -1,0 +1,23 @@
+from typing import Dict, List
+
+import numpy as np
+from torch.utils.tensorboard.writer import SummaryWriter
+
+
+class TrainStats:
+    def __init__(
+        self, step_stats: List[Dict[str, float]], explained_var: float
+    ) -> None:
+        self.step_stats = {
+            k: np.mean([s[k] for s in step_stats]).item() for k in step_stats[0]
+        }
+        self.explained_var = explained_var
+
+    def write_to_tensorboard(self, tb_writer: SummaryWriter, global_step: int) -> None:
+        stats = {**self.step_stats, **{"explained_var": self.explained_var}}
+        for name, value in stats.items():
+            tb_writer.add_scalar(f"losses/{name}", value, global_step=global_step)
+
+    def __repr__(self) -> str:
+        stats = {**self.step_stats, **{"explained_var": self.explained_var}}
+        return " | ".join(f"{k}: {round(v, 2)}" for k, v in stats.items())

--- a/rl_algo_impls/hyperparams/acbc.yml
+++ b/rl_algo_impls/hyperparams/acbc.yml
@@ -1,0 +1,136 @@
+Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
+  additional_keys_to_log:
+    - microrts_stats
+    - microrts_results
+    - results
+    - action_mask_stats
+  algo_hyperparams:
+    learning_rate: 1.0e-05
+    batch_size: 3072
+    n_epochs: 2
+    gamma: 0.999
+    gae_lambda: 0.99
+    vf_coef: 0.25
+    max_grad_norm: 0.5
+    update_returns_between_epochs: true
+    gradient_accumulation: false
+  env_hyperparams:
+    additional_win_loss_reward: false
+    bots:
+      coacAI: 12
+      lightRushAI: 12
+      mayari: 6
+    env_type: microrts_bots
+    make_kwargs:
+      max_steps: 4000
+      reward_weight:
+        - 1.0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    map_paths:
+      - maps/16x16/basesWorkers16x16A.xml
+      - maps/16x16/TwoBasesBarracks16x16.xml
+      - maps/8x8/basesWorkers8x8A.xml
+      - maps/8x8/FourBasesWorkers8x8.xml
+      - maps/NoWhereToRun9x8.xml
+      - maps/16x16/EightBasesWorkers16x16.xml
+    n_envs: 36
+    reference_bot: mayari
+    score_reward_kwargs: null
+    self_play_kwargs: null
+    valid_sizes:
+      - 16
+  env_id: Microrts-squnet-map16
+  eval_hyperparams:
+    deterministic: false
+    env_overrides:
+      additional_win_loss_reward: false
+      bots:
+        coacAI: 2
+        droplet: 2
+        guidedRojoA3N: 2
+        izanagi: 2
+        lightRushAI: 2
+        mayari: 2
+        mixedBot: 2
+        naiveMCTSAI: 2
+        passiveAI: 2
+        randomAI: 2
+        randomBiasedAI: 2
+        rojo: 2
+        tiamat: 2
+        workerRushAI: 2
+      env_type: microrts
+      make_kwargs:
+        bot_envs_alternate_player: false
+        map_paths:
+          - maps/16x16/basesWorkers16x16A.xml
+        max_steps: 4000
+        num_selfplay_envs: 0
+        render_theme: 2
+        reward_weight:
+          - 1.0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+      map_paths: []
+      n_envs: 28
+      score_reward_kwargs: {}
+      self_play_kwargs: {}
+    max_video_length: 4000
+    n_episodes: 28
+    score_function: mean
+    skip_evaluate_at_start: true
+    step_freq: 1000000.0
+  n_timesteps: 300000000.0
+  policy_hyperparams:
+    activation_fn: relu
+    actor_head_style: squeeze_unet
+    additional_critic_activation_functions: []
+    channels_per_level:
+      - 128
+      - 128
+      - 128
+    cnn_flatten_dim: 256
+    cnn_style: microrts
+    decoder_residual_blocks_per_level:
+      - 2
+      - 3
+    deconv_strides_per_level:
+      - - 2
+        - 2
+      - - 2
+        - 2
+    encoder_residual_blocks_per_level:
+      - 3
+      - 2
+      - 4
+    output_activation_fn: tanh
+    strides_per_level:
+      - 4
+      - 4
+    subaction_mask:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 4
+      - 5
+  rollout_hyperparams:
+    n_steps: 512
+  rollout_type: reference
+
+Microrts-debug: &microrts-debug-defaults
+  <<: *microrts-squnet-d16-128-imayari
+  device: mps

--- a/rl_algo_impls/hyperparams/acbc.yml
+++ b/rl_algo_impls/hyperparams/acbc.yml
@@ -13,7 +13,6 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gae_lambda: 0.99
     vf_coef: 0.5
     max_grad_norm: 0.5
-    update_returns_between_epochs: true
     gradient_accumulation: false
     scale_loss_by_num_actions: true
   env_hyperparams:

--- a/rl_algo_impls/hyperparams/acbc.yml
+++ b/rl_algo_impls/hyperparams/acbc.yml
@@ -14,6 +14,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     max_grad_norm: 0.5
     update_returns_between_epochs: true
     gradient_accumulation: false
+    scale_loss_by_num_actions: true
   env_hyperparams:
     additional_win_loss_reward: false
     bots:

--- a/rl_algo_impls/hyperparams/acbc.yml
+++ b/rl_algo_impls/hyperparams/acbc.yml
@@ -1,10 +1,11 @@
 Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
+  n_timesteps: !!float 100e6
   additional_keys_to_log:
     - microrts_stats
     - microrts_results
     - results
     - action_mask_stats
-  algo_hyperparams:
+  algo_hyperparams: &microrts-squnet-d16-128-imayari-algo-hyperparams
     learning_rate: 1.0e-05
     batch_size: 3072
     n_epochs: 2
@@ -94,7 +95,6 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     score_function: mean
     skip_evaluate_at_start: true
     step_freq: 1000000.0
-  n_timesteps: 300000000.0
   policy_hyperparams:
     activation_fn: relu
     actor_head_style: squeeze_unet
@@ -132,6 +132,13 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     n_steps: 512
   rollout_type: reference
 
-Microrts-debug: &microrts-debug-defaults
+Microrts-squnet-d16-128-iMayari-linear-lr:
+  &microrts-squnet-d16-128-imayari-linear-lr
   <<: *microrts-squnet-d16-128-imayari
-  device: mps
+  algo_hyperparams:
+    <<: *microrts-squnet-d16-128-imayari-algo-hyperparams
+    learning_rate_decay: linear
+
+Microrts-debug: &microrts-debug-defaults
+  <<: *microrts-squnet-d16-128-imayari-linear-lr
+  device: cpu

--- a/rl_algo_impls/hyperparams/acbc.yml
+++ b/rl_algo_impls/hyperparams/acbc.yml
@@ -6,7 +6,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     - results
     - action_mask_stats
   algo_hyperparams: &microrts-squnet-d16-128-imayari-algo-hyperparams
-    learning_rate: 1.0e-05
+    learning_rate: 2.0e-05
     batch_size: 3072
     n_epochs: 2
     gamma: 0.999

--- a/rl_algo_impls/hyperparams/acbc.yml
+++ b/rl_algo_impls/hyperparams/acbc.yml
@@ -11,7 +11,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     n_epochs: 2
     gamma: 0.999
     gae_lambda: 0.99
-    vf_coef: 0.25
+    vf_coef: 0.5
     max_grad_norm: 0.5
     update_returns_between_epochs: true
     gradient_accumulation: false

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -637,7 +637,7 @@ _Microrts-squnet-map16: &microrts-squnet-map16
     valid_sizes: [16]
   eval_hyperparams: &microrts-squnet-map16-eval-defaults
     <<: *microrts-squnet-eval-defaults
-    env_overrides:
+    env_overrides: &microrts-squnet-map16-eval-env-overrides
       <<: *microrts-squnet-eval-env-overrides
       make_kwargs:
         <<: *microrts-ai-eval-env-make-kwargs-overrides
@@ -1481,6 +1481,50 @@ Microrts-squnet-d16-128-map64-finetune: &microrts-squnet-d16-128-map64-finetune
       - 0.3
       - 0.2
       - 0.45
+
+Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
+  <<: *microrts-squnet-deep16-128
+  rollout_type: reference
+  env_hyperparams:
+    <<: *microrts-squnet-map16-env-defaults
+    n_envs: 36
+    env_type: microrts_bots
+    map_paths:
+      - maps/16x16/basesWorkers16x16A.xml
+      - maps/16x16/TwoBasesBarracks16x16.xml
+      - maps/8x8/basesWorkers8x8A.xml
+      - maps/8x8/FourBasesWorkers8x8.xml
+      - maps/NoWhereToRun9x8.xml
+      - maps/16x16/EightBasesWorkers16x16.xml
+    make_kwargs:
+      max_steps: 4000
+      reward_weight: [1.0, 0, 0, 0, 0, 0, 0, 0, 0]
+    self_play_kwargs: null
+    reference_bot: mayari
+    bots:
+      mayari: 6
+      coacAI: 12
+      lightRushAI: 12
+    additional_win_loss_reward: false
+    score_reward_kwargs: null
+  policy_hyperparams:
+    <<: *microrts-squnet-deep16-128-policy-defaults
+    additional_critic_activation_functions: []
+    output_activation_fn: tanh
+  algo_hyperparams: &microrts-squnet-d16-128-imayari-algo-defaults
+    <<: *microrts-squnet-deep16-128-algo-defaults
+    batch_size: 3072
+    gradient_accumulation: true
+    gamma: 0.999
+    gae_lambda: 0.99
+    learning_rate: !!float 1e-4
+    vf_coef: 0.5
+    ent_coef: 0.01
+  eval_hyperparams:
+    <<: *microrts-squnet-map16-eval-defaults
+    env_overrides:
+      <<: *microrts-squnet-map16-eval-env-overrides
+      env_type: microrts
 
 Microrts-debug: &microrts-debug-defaults
   <<: *microrts-squnet-d16-128-map64-finetune

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1508,6 +1508,9 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
       lightRushAI: 12
     additional_win_loss_reward: false
     score_reward_kwargs: null
+  rollout_hyperparams:
+    <<: *microrts-ai-rollout-defaults
+    scale_advantage_by_values_accuracy: true
   policy_hyperparams:
     <<: *microrts-squnet-deep16-128-policy-defaults
     additional_critic_activation_functions: []

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -260,7 +260,8 @@ MicrortsRandomEnemyShapedReward3-v1-NoMask:
 _microrts_ai: &microrts-ai-defaults
   <<: *microrts-defaults
   n_timesteps: !!float 100e6
-  additional_keys_to_log: ["microrts_stats", "microrts_results", "results"]
+  additional_keys_to_log:
+    [microrts_stats, microrts_results, results, action_mask_stats]
   env_hyperparams: &microrts-ai-env-defaults
     n_envs: 24
     env_type: microrts

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1524,6 +1524,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     clip_range_vf: 0.1
     normalize_advantage: false
     update_returns_between_epochs: true
+    kl_cutoff: 0.01
   eval_hyperparams:
     <<: *microrts-squnet-map16-eval-defaults
     env_overrides:

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1519,7 +1519,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gamma: 0.999
     gae_lambda: 0.99
     learning_rate: !!float 5e-5
-    vf_coef: 0.25
+    vf_coef: 0.5
     ent_coef: 0.0001
     clip_range_vf: 0.1
     normalize_advantage: false

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1515,10 +1515,10 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
   algo_hyperparams: &microrts-squnet-d16-128-imayari-algo-defaults
     <<: *microrts-squnet-deep16-128-algo-defaults
     batch_size: 3072
-    gradient_accumulation: true
+    gradient_accumulation: false
     gamma: 0.999
     gae_lambda: 0.99
-    learning_rate: !!float 2e-5
+    learning_rate: !!float 1e-5
     vf_coef: 0.5
     ent_coef: 0.0001
     clip_range_vf: 0.1

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1518,7 +1518,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gradient_accumulation: true
     gamma: 0.999
     gae_lambda: 0.99
-    learning_rate: !!float 5e-5
+    learning_rate: !!float 1e-5
     vf_coef: 0.5
     ent_coef: 0.0001
     clip_range_vf: 0.1

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1518,7 +1518,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gradient_accumulation: true
     gamma: 0.999
     gae_lambda: 0.99
-    learning_rate: !!float 1e-5
+    learning_rate: !!float 2e-5
     vf_coef: 0.5
     ent_coef: 0.0001
     clip_range_vf: 0.1

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1519,7 +1519,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gamma: 0.999
     gae_lambda: 0.99
     learning_rate: !!float 1e-4
-    vf_coef: 0.5
+    vf_coef: 0.25
     ent_coef: 0.0001
     clip_range_vf: 0.1
     normalize_advantage: false

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1525,6 +1525,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     normalize_advantage: false
     update_returns_between_epochs: true
     kl_cutoff: 0.01
+    scale_loss_by_num_actions: true
   eval_hyperparams:
     <<: *microrts-squnet-map16-eval-defaults
     env_overrides:

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -275,6 +275,7 @@ _microrts_ai: &microrts-ai-defaults
     <<: *microrts-policy-defaults
     cnn_flatten_dim: 256
     actor_head_style: gridnet
+    subaction_mask: [1, 2, 3, 4, 4, 5]
   rollout_hyperparams: &microrts-ai-rollout-defaults
     n_steps: 512
   algo_hyperparams: &microrts-ai-algo-defaults
@@ -1527,7 +1528,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
       env_type: microrts
 
 Microrts-debug: &microrts-debug-defaults
-  <<: *microrts-squnet-d16-128-map64-finetune
+  <<: *microrts-squnet-d16-128-imayari
   device: mps
 
 Microrts-agent: &microrts-agent

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1523,6 +1523,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     ent_coef: 0.0001
     clip_range_vf: 0.1
     normalize_advantage: false
+    update_returns_between_epochs: true
   eval_hyperparams:
     <<: *microrts-squnet-map16-eval-defaults
     env_overrides:

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1518,7 +1518,8 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
   algo_hyperparams: &microrts-squnet-d16-128-imayari-algo-defaults
     <<: *microrts-squnet-deep16-128-algo-defaults
     batch_size: 3072
-    gradient_accumulation: false
+    n_epochs: 1
+    gradient_accumulation: true
     gamma: 0.999
     gae_lambda: 0.99
     learning_rate: !!float 1e-5

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1518,7 +1518,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gradient_accumulation: true
     gamma: 0.999
     gae_lambda: 0.99
-    learning_rate: !!float 1e-4
+    learning_rate: !!float 5e-5
     vf_coef: 0.25
     ent_coef: 0.0001
     clip_range_vf: 0.1

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1529,7 +1529,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
 
 Microrts-debug: &microrts-debug-defaults
   <<: *microrts-squnet-d16-128-imayari
-  device: mps
+  device: cpu
 
 Microrts-agent: &microrts-agent
   <<: *microrts-sp-dc-phases-defaults

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1526,7 +1526,6 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     ent_coef: 0.0001
     clip_range_vf: 0.1
     normalize_advantage: false
-    update_returns_between_epochs: true
     kl_cutoff: 0.01
     scale_loss_by_num_actions: true
   eval_hyperparams:

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1521,6 +1521,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     learning_rate: !!float 1e-4
     vf_coef: 0.5
     ent_coef: 0.01
+    clip_range_vf: 0.1
   eval_hyperparams:
     <<: *microrts-squnet-map16-eval-defaults
     env_overrides:
@@ -1529,7 +1530,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
 
 Microrts-debug: &microrts-debug-defaults
   <<: *microrts-squnet-d16-128-imayari
-  device: cpu
+  device: mps
 
 Microrts-agent: &microrts-agent
   <<: *microrts-sp-dc-phases-defaults

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1528,6 +1528,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     env_overrides:
       <<: *microrts-squnet-map16-eval-env-overrides
       env_type: microrts
+    skip_evaluate_at_start: true
 
 Microrts-debug: &microrts-debug-defaults
   <<: *microrts-squnet-d16-128-imayari

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1520,7 +1520,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gae_lambda: 0.99
     learning_rate: !!float 1e-4
     vf_coef: 0.5
-    ent_coef: 0.01
+    ent_coef: 0.001
     clip_range_vf: 0.1
     normalize_advantage: false
   eval_hyperparams:

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1520,7 +1520,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     gae_lambda: 0.99
     learning_rate: !!float 1e-4
     vf_coef: 0.5
-    ent_coef: 0.001
+    ent_coef: 0.0001
     clip_range_vf: 0.1
     normalize_advantage: false
   eval_hyperparams:

--- a/rl_algo_impls/hyperparams/ppo.yml
+++ b/rl_algo_impls/hyperparams/ppo.yml
@@ -1522,6 +1522,7 @@ Microrts-squnet-d16-128-iMayari: &microrts-squnet-d16-128-imayari
     vf_coef: 0.5
     ent_coef: 0.01
     clip_range_vf: 0.1
+    normalize_advantage: false
   eval_hyperparams:
     <<: *microrts-squnet-map16-eval-defaults
     env_overrides:

--- a/rl_algo_impls/lux/vec_env/lux.py
+++ b/rl_algo_impls/lux/vec_env/lux.py
@@ -57,6 +57,7 @@ def make_lux_env(
         _,  # terrain_overrides,
         _,  # time_budget_ms,
         _,  # video_frames_per_second,
+        _,  # reference_bot,
     ) = astuple(hparams)
 
     seed = config.seed(training=training)

--- a/rl_algo_impls/microrts/java/RAISocketAI.jar
+++ b/rl_algo_impls/microrts/java/RAISocketAI.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5bf0176814bafbb49220a53ec9c1fd3c70b0b2e97d3857bb10770bd002a505e4
-size 381498
+oid sha256:a55501e8e775a79d096c5c4331b2c2621f04e6edf3e52e43463db13dd3f79048
+size 389101

--- a/rl_algo_impls/microrts/java/src/ai/rai/RAIBotResponse.java
+++ b/rl_algo_impls/microrts/java/src/ai/rai/RAIBotResponse.java
@@ -1,0 +1,17 @@
+package ai.rai;
+
+public class RAIBotResponse extends RAIResponse {
+    public int[][] action;
+
+    public RAIBotResponse(byte[] observation, byte[] mask, double reward[], boolean done[], String info, byte[] terrain,
+            byte[] resources, int[][] action) {
+        super(observation, mask, reward, done, info, terrain, resources);
+        this.action = action;
+    }
+
+    public void set(byte[] observation, byte[] mask, double reward[], boolean done[], String info, byte[] terrain,
+            byte[] resources, int[][] action) {
+        super.set(observation, mask, reward, done, info, terrain, resources);
+        this.action = action;
+    }
+}

--- a/rl_algo_impls/microrts/java/src/ai/rai/RAIBotResponses.java
+++ b/rl_algo_impls/microrts/java/src/ai/rai/RAIBotResponses.java
@@ -1,0 +1,18 @@
+package ai.rai;
+
+public class RAIBotResponses extends RAIResponses {
+
+    public int[][][] action;
+
+    public RAIBotResponses(byte[][] observation, byte[][] mask, double reward[][], boolean done[][], byte terrain[][],
+            byte resources[][], int[][][] action) {
+        super(observation, mask, reward, done, terrain, resources);
+        this.action = action;
+    }
+
+    public void set(byte[][] observation, byte[][] mask, double reward[][], boolean done[][], byte terrain[][],
+            byte resources[][], int[][][] action) {
+        super.set(observation, mask, reward, done, terrain, resources);
+        this.action = action;
+    }
+}

--- a/rl_algo_impls/microrts/java/src/tests/RAIBotClient.java
+++ b/rl_algo_impls/microrts/java/src/tests/RAIBotClient.java
@@ -1,0 +1,231 @@
+package tests;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.awt.image.WritableRaster;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.file.Paths;
+
+import ai.core.AI;
+import ai.jni.JNIAI;
+import ai.jni.Response;
+import ai.rai.RAIBotResponse;
+import ai.rai.GameStateWrapper;
+import ai.reward.RewardFunctionInterface;
+import gui.PhysicalGameStateJFrame;
+import gui.PhysicalGameStatePanel;
+import rts.GameState;
+import rts.PartiallyObservableGameState;
+import rts.PhysicalGameState;
+import rts.PlayerAction;
+import rts.TraceEntry;
+import rts.units.Unit;
+import rts.units.UnitTypeTable;
+
+/**
+ * Instances of this class each let us run a single environment (or sequence
+ * of them, if we reset() in between) between two players.
+ * 
+ * In this client, it is assumed that actions are selected by Java-based bots
+ * for **both** players. See RAIGridnetClient.java for a client where one
+ * player is externally controlled, and RAIGridnetClientSelfPlay.java for one
+ * where both players are externally controlled.
+ *
+ * @author santi and costa
+ */
+public class RAIBotClient {
+
+    PhysicalGameStateJFrame w;
+    public AI ais[];
+    public PhysicalGameState pgs;
+    public GameState gs;
+    public GameState[] playergs = new GameState[2];
+    UnitTypeTable utt;
+    boolean partialObs;
+    public RewardFunctionInterface[] rfs;
+    public String mapPath;
+    String micrortsPath;
+    boolean gameover = false;
+    boolean layerJSON = true;
+    public int renderTheme = PhysicalGameStatePanel.COLORSCHEME_WHITE;
+    public int maxAttackRadius;
+    public final int numPlayers = 2;
+
+    // storage
+    int[][][][] masks = new int[2][][][];
+    double[][] rewards = new double[2][];
+    boolean[][] dones = new boolean[2][];
+    RAIBotResponse[] response = new RAIBotResponse[2];
+    PlayerAction[] pas = new PlayerAction[2];
+
+    /**
+     * 
+     * @param a_rfs          Reward functions we want to use to compute rewards at
+     *                       every step.
+     * @param a_micrortsPath Path for the microrts root directory (with Java code
+     *                       and maps).
+     * @param a_mapPath      Path (under microrts root dir) for map to load.
+     * @param a_ai1
+     * @param a_ai2
+     * @param a_utt
+     * @param partial_obs
+     * @throws Exception
+     */
+    public RAIBotClient(RewardFunctionInterface[] a_rfs, String a_micrortsPath, String a_mapPath, AI a_ai1, AI a_ai2,
+            UnitTypeTable a_utt, boolean partial_obs) throws Exception {
+        micrortsPath = a_micrortsPath;
+        mapPath = a_mapPath;
+        rfs = a_rfs;
+        utt = a_utt;
+        partialObs = partial_obs;
+        if (a_ai1 == null || a_ai2 == null) {
+            throw new Exception("no ai1 or ai2 was chosen");
+        }
+        if (micrortsPath.length() != 0) {
+            this.mapPath = Paths.get(micrortsPath, mapPath).toString();
+        }
+
+        pgs = PhysicalGameState.load(mapPath, utt);
+
+        ais = new AI[] { a_ai1, a_ai2 };
+        // initialize storage
+        for (int i = 0; i < numPlayers; i++) {
+            masks[i] = new int[pgs.getHeight()][pgs.getWidth()][1 + 6 + 4 + 4 + 4 + 4 + utt.getUnitTypes().size()
+                    + maxAttackRadius * maxAttackRadius];
+            rewards[i] = new double[rfs.length];
+            dones[i] = new boolean[rfs.length];
+            response[i] = new RAIBotResponse(null, null, null, null, null, null, null, null);
+        }
+    }
+
+    public byte[] render(boolean returnPixels) throws Exception {
+        if (w == null) {
+            w = PhysicalGameStatePanel.newVisualizer(gs, 640, 640, false, null, renderTheme);
+        }
+        w.setStateCloning(gs);
+        w.repaint();
+
+        if (!returnPixels) {
+            return null;
+        }
+        BufferedImage image = new BufferedImage(w.getWidth(),
+                w.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+        w.paint(image.getGraphics());
+
+        WritableRaster raster = image.getRaster();
+        DataBufferByte data = (DataBufferByte) raster.getDataBuffer();
+        return data.getData();
+    }
+
+    public void gameStep() throws Exception {
+        TraceEntry te = new TraceEntry(gs.getPhysicalGameState().clone(), gs.getTime());
+        var errored = false;
+        int[][][] vectorAction = new int[numPlayers][][];
+        for (int i = 0; i < numPlayers; ++i) {
+            playergs[i] = gs;
+            if (partialObs) {
+                playergs[i] = new PartiallyObservableGameState(gs, i);
+            }
+            try {
+                pas[i] = ais[i].getAction(i, playergs[i]);
+            } catch (Throwable e) {
+                System.err.println("Player " + i + " Error: " + e.getMessage());
+                e.printStackTrace();
+
+                final var p = i;
+                // Remove all AI units, which should cause it to auto-lose.
+                var unitsToRemove = gs.getUnits().stream().filter(u -> u.getPlayer() == p).toArray(Unit[]::new);
+                for (Unit u : unitsToRemove) {
+                    gs.removeUnit(u);
+                }
+                errored = true;
+                break;
+            }
+            gs.issueSafe(pas[i]);
+            te.addPlayerAction(pas[i].clone());
+            vectorAction[i] = GameStateWrapper.toVectorAction(gs, pas[i]);
+        }
+
+        // simulate:
+        if (!errored) {
+            gameover = gs.cycle();
+        }
+        if (gameover || errored) {
+            for (int i = 0; i < numPlayers; ++i) {
+                ais[i].gameOver(gs.winner());
+            }
+        }
+
+        for (int i = 0; i < numPlayers; i++) {
+            for (int j = 0; j < rfs.length; j++) {
+                rfs[j].computeReward(i, 1 - i, te, gs);
+                rewards[i][j] = rfs[j].getReward();
+                dones[i][j] = rfs[j].isDone();
+            }
+            var gsw = new GameStateWrapper(gs);
+            response[i].set(
+                    gsw.getArrayObservation(i),
+                    gsw.getBinaryMask(i),
+                    rewards[i],
+                    dones[i],
+                    "{}",
+                    null,
+                    gsw.getPlayerResources(i),
+                    vectorAction[i]);
+        }
+    }
+
+    public String sendUTT() throws Exception {
+        Writer w = new StringWriter();
+        utt.toJSON(w);
+        return w.toString(); // now it works fine
+    }
+
+    /**
+     * Resets the environment.
+     * 
+     * @throws Exception
+     */
+    public void reset() throws Exception {
+        pgs = PhysicalGameState.load(mapPath, utt);
+        gs = new GameState(pgs, utt);
+
+        for (int i = 0; i < numPlayers; i++) {
+            playergs[i] = gs;
+            if (partialObs) {
+                playergs[i] = new PartiallyObservableGameState(gs, i);
+            }
+
+            ais[i] = ais[i].clone();
+            ais[i].reset();
+
+            for (int j = 0; j < rewards.length; j++) {
+                rewards[i][j] = 0;
+                dones[i][j] = false;
+            }
+
+            var gsw = new GameStateWrapper(gs);
+            response[i].set(
+                    gsw.getArrayObservation(i),
+                    gsw.getBinaryMask(i),
+                    rewards[i],
+                    dones[i],
+                    "{}",
+                    gsw.getTerrain(),
+                    gsw.getPlayerResources(i),
+                    null);
+        }
+    }
+
+    public RAIBotResponse getResponse(int player) {
+        return response[player];
+    }
+
+    public void close() throws Exception {
+        if (w != null) {
+            System.out.println(this.getClass().getSimpleName() + ": Not disposing frame. Resource Leak!");
+            // w.dispose();
+        }
+    }
+}

--- a/rl_algo_impls/microrts/java/src/tests/RAIBotGridnetVecClient.java
+++ b/rl_algo_impls/microrts/java/src/tests/RAIBotGridnetVecClient.java
@@ -1,0 +1,155 @@
+package tests;
+
+import java.util.Arrays;
+
+import ai.core.AI;
+import ai.rai.RAIBotResponse;
+import ai.rai.RAIBotResponses;
+import ai.reward.RewardFunctionInterface;
+import rts.units.UnitTypeTable;
+
+public class RAIBotGridnetVecClient {
+    public RAIBotClient[] botClients;
+
+    public int maxSteps;
+    public int[] envSteps;
+    public RewardFunctionInterface[] rfs;
+    public UnitTypeTable utt;
+    boolean partialObs = false;
+    public String[] mapPaths;
+
+    // storage
+    byte[][] mask;
+    byte[][] observation;
+    double[][] reward;
+    boolean[][] done;
+    byte[][] resources;
+    RAIBotResponse[] rs;
+    RAIBotResponses responses;
+    byte[][] terrain;
+    int[][][] action;
+
+    double[] terminalReward1;
+    boolean[] terminalDone1;
+    int[][] terminalAction1;
+    double[] terminalReward2;
+    boolean[] terminalDone2;
+    int[][] terminalAction2;
+
+    /**
+     * Constructor for Java-bot-only environments.
+     * 
+     * @param a_max_steps
+     * @param a_rfs
+     * @param a_micrortsPath
+     * @param a_mapPaths
+     * @param a_ais
+     * @param a_utt
+     * @param partial_obs
+     * @throws Exception
+     */
+    public RAIBotGridnetVecClient(int a_max_steps, RewardFunctionInterface[] a_rfs, String a_micrortsPath,
+            String[] a_mapPaths,
+            AI[] a_ais, UnitTypeTable a_utt, boolean partial_obs) throws Exception {
+        maxSteps = a_max_steps;
+        utt = a_utt;
+        rfs = a_rfs;
+        partialObs = partial_obs;
+        mapPaths = a_mapPaths;
+
+        // initialize clients
+        botClients = new RAIBotClient[a_ais.length / 2];
+        for (int i = 0; i < botClients.length; i++) {
+            botClients[i] = new RAIBotClient(a_rfs, a_micrortsPath, mapPaths[2 * i], a_ais[2 * i], a_ais[2 * i + 1],
+                    a_utt,
+                    partialObs);
+        }
+
+        int s1 = botClients.length * 2;
+        envSteps = new int[s1];
+        mask = new byte[s1][];
+        observation = new byte[s1][];
+        reward = new double[s1][rfs.length];
+        done = new boolean[s1][rfs.length];
+        resources = new byte[s1][2];
+        terminalReward1 = new double[rfs.length];
+        terminalDone1 = new boolean[rfs.length];
+        terminalReward2 = new double[rfs.length];
+        terminalDone2 = new boolean[rfs.length];
+        responses = new RAIBotResponses(null, null, null, null, null, null, null);
+        terrain = new byte[s1][];
+        action = new int[s1][][];
+        rs = new RAIBotResponse[s1];
+    }
+
+    public RAIBotResponses reset() throws Exception {
+        for (int i = 0; i < botClients.length; i++) {
+            botClients[i].reset();
+            for (int p = 0; p < 2; ++p) {
+                rs[i * 2 + p] = botClients[i].getResponse(p);
+            }
+        }
+        Arrays.fill(envSteps, 0);
+
+        for (int i = 0; i < rs.length; i++) {
+            observation[i] = rs[i].observation;
+            mask[i] = rs[i].mask;
+            reward[i] = rs[i].reward;
+            done[i] = rs[i].done;
+            terrain[i] = rs[i].terrain;
+            resources[i] = rs[i].resources;
+        }
+        responses.set(observation, mask, reward, done, terrain, resources, null);
+        return responses;
+    }
+
+    public RAIBotResponses gameStep() throws Exception {
+        for (int i = 0; i < botClients.length; i++) {
+            botClients[i].gameStep();
+            for (int p = 0; p < 2; ++p) {
+                rs[i * 2 + p] = botClients[i].getResponse(p);
+                envSteps[i * 2 + p] += 1;
+            }
+            if (rs[i * 2].done[0] || envSteps[i * 2] >= maxSteps) {
+                for (int j = 0; j < terminalReward1.length; j++) {
+                    terminalReward1[j] = rs[i * 2].reward[j];
+                    terminalDone1[j] = rs[i * 2].done[j];
+                    terminalReward2[j] = rs[i * 2 + 1].reward[j];
+                    terminalDone2[j] = rs[i * 2 + 1].done[j];
+                }
+                terminalAction1 = rs[i * 2].action;
+                terminalAction2 = rs[i * 2 + 1].action;
+
+                botClients[i].reset();
+                for (int j = 0; j < terminalReward1.length; j++) {
+                    rs[i * 2].reward[j] = terminalReward1[j];
+                    rs[i * 2].done[j] = terminalDone1[j];
+                    rs[i * 2 + 1].reward[j] = terminalReward2[j];
+                    rs[i * 2 + 1].done[j] = terminalDone2[j];
+                }
+                rs[i * 2].done[0] = true;
+                rs[i * 2 + 1].done[0] = true;
+                rs[i * 2].action = terminalAction1;
+                rs[i * 2 + 1].action = terminalAction2;
+                envSteps[i * 2] = 0;
+                envSteps[i * 2 + 1] = 0;
+            }
+        }
+        for (int i = 0; i < rs.length; i++) {
+            observation[i] = rs[i].observation;
+            mask[i] = rs[i].mask;
+            reward[i] = rs[i].reward;
+            done[i] = rs[i].done;
+            resources[i] = rs[i].resources;
+            action[i] = rs[i].action;
+        }
+        responses.set(observation, mask, reward, done, null, resources, action);
+        return responses;
+    }
+
+    public void close() throws Exception {
+        for (int i = 0; i < botClients.length; i++) {
+            botClients[i].close();
+        }
+    }
+}

--- a/rl_algo_impls/microrts/java/src/tests/RAIGridnetVecClient.java
+++ b/rl_algo_impls/microrts/java/src/tests/RAIGridnetVecClient.java
@@ -122,9 +122,9 @@ public class RAIGridnetVecClient {
             selfPlayClients[i].reset();
             for (int p = 0; p < 2; ++p) {
                 rs[i * 2 + p] = selfPlayClients[i].getResponse(p);
-                envSteps[i * 2 + p] = 0;
             }
         }
+        Arrays.fill(envSteps, 0);
         for (int i = selfPlayClients.length * 2; i < players.length; i++) {
             rs[i] = clients[i - selfPlayClients.length * 2].reset(players[i]);
         }

--- a/rl_algo_impls/microrts/java/src/tests/RAIGridnetVecClient.java
+++ b/rl_algo_impls/microrts/java/src/tests/RAIGridnetVecClient.java
@@ -120,8 +120,10 @@ public class RAIGridnetVecClient {
     public RAIResponses reset(int[] players) throws Exception {
         for (int i = 0; i < selfPlayClients.length; i++) {
             selfPlayClients[i].reset();
-            rs[i * 2] = selfPlayClients[i].getResponse(0);
-            rs[i * 2 + 1] = selfPlayClients[i].getResponse(1);
+            for (int p = 0; p < 2; ++p) {
+                rs[i * 2 + p] = selfPlayClients[i].getResponse(p);
+                envSteps[i * 2 + p] = 0;
+            }
         }
         for (int i = selfPlayClients.length * 2; i < players.length; i++) {
             rs[i] = clients[i - selfPlayClients.length * 2].reset(players[i]);

--- a/rl_algo_impls/microrts/java/src/tests/RAIGridnetVecClient.java
+++ b/rl_algo_impls/microrts/java/src/tests/RAIGridnetVecClient.java
@@ -76,9 +76,9 @@ public class RAIGridnetVecClient {
     byte[][] terrain;
 
     double[] terminalReward1;
-    boolean[] terminalRone1;
+    boolean[] terminalDone1;
     double[] terminalReward2;
-    boolean[] terminalRone2;
+    boolean[] terminalDone2;
 
     public RAIGridnetVecClient(int a_num_selfplayenvs, int a_num_envs, int a_max_steps, RewardFunctionInterface[] a_rfs,
             String a_micrortsPath, String[] a_mapPaths,
@@ -109,9 +109,9 @@ public class RAIGridnetVecClient {
         done = new boolean[s1][rfs.length];
         resources = new byte[s1][2];
         terminalReward1 = new double[rfs.length];
-        terminalRone1 = new boolean[rfs.length];
+        terminalDone1 = new boolean[rfs.length];
         terminalReward2 = new double[rfs.length];
-        terminalRone2 = new boolean[rfs.length];
+        terminalDone2 = new boolean[rfs.length];
         responses = new RAIResponses(null, null, null, null, null, null);
         terrain = new byte[s1][];
         rs = new RAIResponse[s1];
@@ -149,17 +149,17 @@ public class RAIGridnetVecClient {
             if (rs[i * 2].done[0] || envSteps[i * 2] >= maxSteps) {
                 for (int j = 0; j < terminalReward1.length; j++) {
                     terminalReward1[j] = rs[i * 2].reward[j];
-                    terminalRone1[j] = rs[i * 2].done[j];
+                    terminalDone1[j] = rs[i * 2].done[j];
                     terminalReward2[j] = rs[i * 2 + 1].reward[j];
-                    terminalRone2[j] = rs[i * 2 + 1].done[j];
+                    terminalDone2[j] = rs[i * 2 + 1].done[j];
                 }
 
                 selfPlayClients[i].reset();
                 for (int j = 0; j < terminalReward1.length; j++) {
                     rs[i * 2].reward[j] = terminalReward1[j];
-                    rs[i * 2].done[j] = terminalRone1[j];
+                    rs[i * 2].done[j] = terminalDone1[j];
                     rs[i * 2 + 1].reward[j] = terminalReward2[j];
-                    rs[i * 2 + 1].done[j] = terminalRone2[j];
+                    rs[i * 2 + 1].done[j] = terminalDone2[j];
                 }
                 rs[i * 2].done[0] = true;
                 rs[i * 2 + 1].done[0] = true;
@@ -176,12 +176,12 @@ public class RAIGridnetVecClient {
                 // so we need to set the old reward and done to this response
                 for (int j = 0; j < rs[i].reward.length; j++) {
                     terminalReward1[j] = rs[i].reward[j];
-                    terminalRone1[j] = rs[i].done[j];
+                    terminalDone1[j] = rs[i].done[j];
                 }
                 clients[i - selfPlayClients.length * 2].reset(players[i]);
                 for (int j = 0; j < rs[i].reward.length; j++) {
                     rs[i].reward[j] = terminalReward1[j];
-                    rs[i].done[j] = terminalRone1[j];
+                    rs[i].done[j] = terminalDone1[j];
                 }
                 rs[i].done[0] = true;
                 envSteps[i] = 0;

--- a/rl_algo_impls/microrts/vec_env/microrts.py
+++ b/rl_algo_impls/microrts/vec_env/microrts.py
@@ -194,6 +194,7 @@ def make_microrts_env(
             bots,
             make_kwargs.get("map_paths"),
         )
+    envs = ActionMaskStatsRecorder(envs)
     if training:
         assert tb_writer
         envs = EpisodeStatsWriter(

--- a/rl_algo_impls/microrts/vec_env/microrts.py
+++ b/rl_algo_impls/microrts/vec_env/microrts.py
@@ -190,7 +190,6 @@ def make_microrts_env(
     if not is_agent:
         envs = MicrortsStatsRecorder(
             envs,
-            config.algo_hyperparams.get("gamma", 0.99),
             bots,
             make_kwargs.get("map_paths"),
         )

--- a/rl_algo_impls/microrts/vec_env/microrts.py
+++ b/rl_algo_impls/microrts/vec_env/microrts.py
@@ -13,6 +13,7 @@ from rl_algo_impls.microrts.wrappers.microrts_stats_recorder import (
     MicrortsStatsRecorder,
 )
 from rl_algo_impls.runner.config import Config, EnvHyperparams
+from rl_algo_impls.wrappers.action_mask_stats_recorder import ActionMaskStatsRecorder
 from rl_algo_impls.wrappers.action_mask_wrapper import MicrortsMaskWrapper
 from rl_algo_impls.wrappers.additional_win_loss_reward import (
     AdditionalWinLossRewardWrapper,
@@ -63,6 +64,7 @@ def make_microrts_env(
         terrain_overrides,
         time_budget_ms,
         video_frames_per_second,
+        _,  # reference_bot,
     ) = astuple(hparams)
 
     seed = config.seed(training=training)

--- a/rl_algo_impls/microrts/vec_env/microrts_bot_vec_env.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_bot_vec_env.py
@@ -1,0 +1,364 @@
+import atexit
+import json
+import logging
+import os
+import sys
+import warnings
+import xml.etree.ElementTree as ET
+from itertools import cycle
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TypeVar
+
+import jpype
+import jpype.imports
+import numpy as np
+from jpype.imports import registerDomain
+from jpype.types import JArray, JInt
+from PIL import Image
+
+from rl_algo_impls.microrts.vec_env.microrts_interface import (
+    ByteArray,
+    MicroRTSInterface,
+    MicroRTSInterfaceListener,
+)
+from rl_algo_impls.microrts.vec_env.microrts_vec_env import to_byte_array_list
+
+MICRORTS_MAC_OS_RENDER_MESSAGE = """
+gym-microrts render is not available on MacOS. See https://github.com/jpype-project/jpype/issues/906
+
+It is however possible to record the videos via `env.render(mode='rgb_array')`. 
+See https://github.com/vwxyzjn/gym-microrts/blob/b46c0815efd60ae959b70c14659efb95ef16ffb0/hello_world_record_video.py
+as an example.
+"""
+
+MicroRTSBotGridVecEnvSelf = TypeVar(
+    "MicroRTSBotGridVecEnvSelf", bound="MicroRTSBotGridVecEnv"
+)
+
+UTT_VERSION_ORIGINAL_FINETUNED = 2
+
+
+class MicroRTSBotGridVecEnv(MicroRTSInterface):
+    DEBUG_VERIFY = True
+
+    def __init__(
+        self,
+        ais,
+        reference_indexes: List[int],
+        partial_obs=False,
+        max_steps=2000,
+        render_theme=2,
+        frame_skip=0,
+        map_paths=["maps/10x10/basesTwoWorkers10x10.xml"],
+        reward_weight=np.array([1.0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        cycle_maps=[],
+        video_frames_per_second: Optional[int] = None,
+    ):
+        self._num_envs = len(reference_indexes)
+        self._partial_obs = partial_obs
+        self.max_steps = max_steps
+        self.render_theme = render_theme
+        self.frame_skip = frame_skip
+        self.ais = ais
+        self.reference_indexes = reference_indexes
+        self.players = [idx % 2 for idx in reference_indexes]
+        self.map_paths = map_paths
+        if len(map_paths) == 1:
+            self.map_paths = [map_paths[0] for _ in range(len(ais))]
+        else:
+            assert len(map_paths) == len(
+                ais
+            ), "if multiple maps are provided, they should be provided for each environment"
+        self.reward_weight = reward_weight
+        self.metadata = {
+            "render.modes": ["human", "rgb_array"],
+            "video.frames_per_second": video_frames_per_second
+            if video_frames_per_second is not None
+            else 150,
+        }
+
+        self.microrts_path = os.path.join(Path(__file__).parent.parent, "java")
+
+        # prepare training maps
+        self.cycle_maps = list(
+            map(lambda i: os.path.join(self.microrts_path, i), cycle_maps)
+        )
+        self.next_map = cycle(self.cycle_maps)
+
+        self._heights = []
+        self._widths = []
+        for mp in self.map_paths:
+            root = ET.parse(os.path.join(self.microrts_path, mp)).getroot()
+            h = int(root.get("height"))
+            w = int(root.get("width"))
+            self._heights.append(h)
+            self._widths.append(w)
+        self._selected_heights = None
+        self._selected_widths = None
+
+        # launch the JVM
+        if not jpype._jpype.isStarted():
+            registerDomain("ts", alias="tests")
+            registerDomain("ai")
+            jars = [
+                "RAISocketAI.jar",
+                "lib/microrts.jar",
+                "lib/bots/Coac.jar",
+                "lib/bots/Droplet.jar",
+                "lib/bots/GRojoA3N.jar",
+                "lib/bots/Izanagi.jar",
+                "lib/bots/MixedBot.jar",
+                "lib/bots/TiamatBot.jar",
+                "lib/bots/UMSBot.jar",
+                "lib/bots/mayariBot.jar",  # "MindSeal.jar"
+            ]
+            for jar in jars:
+                jpype.addClassPath(os.path.join(self.microrts_path, jar))
+            jpype.startJVM(convertStrings=False)
+            atexit.register(jpype.shutdownJVM)
+
+        # start microrts client
+        from rts.units import UnitTypeTable
+
+        self.real_utt = UnitTypeTable(UTT_VERSION_ORIGINAL_FINETUNED)
+        from ai.reward import (
+            AttackRewardFunction,
+            ProduceBuildingRewardFunction,
+            ProduceHeavyUnitRewardFunction,
+            ProduceLightUnitRewardFunction,
+            ProduceRangedUnitRewardFunction,
+            ProduceWorkerRewardFunction,
+            RAIWinLossRewardFunction,
+            ResourceGatherRewardFunction,
+            RewardFunctionInterface,
+            ScoreRewardFunction,
+        )
+
+        self.rfs = JArray(RewardFunctionInterface)(
+            [
+                RAIWinLossRewardFunction(),
+                ResourceGatherRewardFunction(),
+                ProduceWorkerRewardFunction(),
+                ProduceBuildingRewardFunction(),
+                AttackRewardFunction(),
+                ProduceLightUnitRewardFunction(),
+                ProduceRangedUnitRewardFunction(),
+                ProduceHeavyUnitRewardFunction(),
+                ScoreRewardFunction(),
+                # CloserToEnemyBaseRewardFunction(),
+            ]
+        )
+        self.raw_names = [str(rf) for rf in self.rfs]
+        self.start_client()
+
+        self.delta_rewards = np.zeros(len(ais), dtype=np.float32)
+
+    def start_client(self):
+        from ai.core import AI
+        from ts import RAIBotGridnetVecClient as Client
+
+        self.vec_client = Client(
+            self.max_steps,
+            self.rfs,
+            os.path.expanduser(self.microrts_path),
+            self.map_paths,
+            JArray(AI)([ai(self.real_utt) for ai in self.ais]),
+            self.real_utt,
+            self.partial_obs,
+        )
+        self.render_client = (
+            self.vec_client.botClients[0]
+            if len(self.vec_client.botClients) > 0
+            else self.vec_client.clients[0]
+        )
+        # get the unit type table
+        self._utt = json.loads(str(self.render_client.sendUTT()))
+
+    def reset(self):
+        self.delta_rewards = np.zeros_like(self.delta_rewards)
+
+        responses = self.vec_client.reset()
+        self._resources = to_byte_array_list(responses.resources)
+        self._terrain = to_byte_array_list(responses.terrain)
+        return (
+            select(to_byte_array_list(responses.observation), self.reference_indexes),
+            select(to_byte_array_list(responses.mask), self.reference_indexes),
+        )
+
+    def _encode_info(
+        self, batch_rewards: np.ndarray, done: np.ndarray
+    ) -> List[Dict[str, Any]]:
+        infos = []
+        for idx, (rewards, d) in enumerate(zip(batch_rewards, done)):
+            score_reward = rewards[self.raw_names.index("ScoreRewardFunction")]
+            delta_reward = score_reward - self.delta_rewards[idx]
+            info = {
+                "raw_rewards": rewards,
+                "score_reward": {
+                    "reward": score_reward,
+                    "delta_reward": delta_reward,
+                },
+            }
+            if d:
+                winloss = rewards[self.raw_names.index("RAIWinLossRewardFunction")]
+                if np.sign(score_reward) != np.sign(winloss) and np.sign(winloss) != 0:
+                    logging.warn(
+                        f"score_reward {score_reward} must be same sign as winloss {winloss}"
+                    )
+                info["results"] = {
+                    "score_reward": score_reward,
+                    "WinLoss": winloss,
+                    "win": int(winloss == 1),
+                    "draw": int(winloss == 0),
+                    "loss": int(winloss == -1),
+                }
+            infos.append(info)
+            self.delta_rewards[idx] = score_reward if not d else 0
+        return infos
+
+    def step_async(self, actions):
+        pass
+
+    def step_wait(self):
+        responses = self.vec_client.gameStep()
+        reward, done = np.array(responses.reward), np.array(responses.done)
+        obs = to_byte_array_list(responses.observation)
+        mask = to_byte_array_list(responses.mask)
+        self._resources = to_byte_array_list(responses.resources)
+        infos = self._encode_info(reward, done[:, 0])
+        self._action = java_action_to_python_action_list(responses.action)
+
+        # check if it is in evaluation, if not, then change maps
+        if len(self.cycle_maps) > 0:
+            # check if an environment is done, if done, reset the client, and replace the observation
+            for done_idx, d in enumerate(done[:, 0]):
+                if not d:
+                    continue
+                if done_idx % 2 == 1:
+                    continue
+                self.vec_client.botClients[done_idx // 2].mapPath = next(self.next_map)
+                self.vec_client.botClients[done_idx // 2].reset(self.players[done_idx])
+                p0_response = self.vec_client.botClients[done_idx // 2].getResponse(0)
+                p1_response = self.vec_client.botClients[done_idx // 2].getResponse(1)
+                obs[done_idx] = np.array(p0_response.observation)
+                obs[done_idx + 1] = np.array(p1_response.observation)
+                mask[done_idx] = np.array(p0_response.mask)
+                mask[done_idx + 1] = np.array(p1_response.mask)
+                self._terrain[done_idx] = np.array(p0_response.terrain)
+                self._terrain[done_idx + 1] = np.array(p1_response.terrain)
+                self._resources[done_idx] = np.array(p0_response.resources)
+                self._resources[done_idx + 1] = np.array(p1_response.resources)
+        return (
+            select(obs, self.reference_indexes),
+            select(mask, self.reference_indexes),
+            reward[self.reference_indexes] @ self.reward_weight,
+            done[self.reference_indexes, 0],
+            select(infos, self.reference_indexes),
+        )
+
+    def step(self, ac):
+        self.step_async(ac)
+        return self.step_wait()
+
+    @property
+    def num_envs(self):
+        return self._num_envs
+
+    @property
+    def heights(self) -> List[int]:
+        if self._selected_heights is None:
+            self._selected_heights = select(self._heights, self.reference_indexes)
+        return self._selected_heights
+
+    @property
+    def widths(self) -> List[int]:
+        if self._selected_widths is None:
+            self._selected_widths = select(self._widths, self.reference_indexes)
+        return self._selected_widths
+
+    @property
+    def utt(self) -> Dict[str, Any]:
+        return self._utt
+
+    @property
+    def partial_obs(self) -> bool:
+        return self._partial_obs
+
+    def terrain(self, env_idx: int) -> np.ndarray:
+        return self._terrain[self.reference_indexes[env_idx]].reshape(
+            (self.heights[env_idx], self.widths[env_idx])
+        )
+
+    def terrain_md5(self, env_idx: int) -> str:
+        import hashlib
+
+        hash_obj = hashlib.md5()
+        hash_obj.update(self.terrain(env_idx).tobytes())
+        return hash_obj.hexdigest()
+
+    def resources(self, env_idx: int) -> np.ndarray:
+        return self._resources[self.reference_indexes[env_idx]]
+
+    @property
+    def last_action(self) -> List[List[List[int]]]:
+        return select(self._action, self.reference_indexes)
+
+    def render(self, mode="human"):
+        if mode == "human":
+            self.render_client.render(False)
+            # give warning on macos because the render is not available
+            if sys.platform == "darwin":
+                warnings.warn(MICRORTS_MAC_OS_RENDER_MESSAGE)
+        elif mode == "rgb_array":
+            bytes_array = np.array(self.render_client.render(True))
+            image = Image.frombytes("RGB", (640, 640), bytes_array)
+            return np.array(image)[:, :, ::-1]
+
+    def close(self, **kwargs):
+        if jpype._jpype.isStarted():
+            self.vec_client.close()
+
+    def add_listener(self, listener: MicroRTSInterfaceListener) -> None:
+        pass
+
+    def remove_listener(self, listener: MicroRTSInterfaceListener) -> None:
+        pass
+
+    def debug_matrix_obs(self, env_idx: int) -> Optional[np.ndarray]:
+        if not self.DEBUG_VERIFY:
+            return None
+        from ai.rai import GameStateWrapper
+
+        underlying_idx = self.reference_indexes[env_idx]
+        gsw = GameStateWrapper(self.vec_client.botClients[underlying_idx // 2].gs)
+        player_id = self.players[env_idx]
+        return np.transpose(np.array(gsw.getVectorObservation(player_id)), (1, 2, 0))
+
+    def debug_matrix_mask(self, env_idx: int) -> Optional[np.ndarray]:
+        if not self.DEBUG_VERIFY:
+            return None
+
+        from ai.rai import GameStateWrapper
+
+        underlying_idx = self.reference_indexes[env_idx]
+        gsw = GameStateWrapper(self.vec_client.botClients[underlying_idx // 2].gs)
+        player_id = self.players[env_idx]
+
+        return np.array(gsw.getMasks(player_id))
+
+
+T = TypeVar("T")
+
+
+def select(a: List[T], indexes: List[int]) -> List[T]:
+    return [a[idx] for idx in indexes]
+
+
+def java_action_to_python_action_list(j_action) -> List[List[List[int]]]:
+    p_a = []
+    for j_a_in_env in j_action:
+        p_a_in_env = []
+        for j_a in j_a_in_env:
+            p_a_in_env.append(list(j_a))
+        p_a.append(p_a_in_env)
+    return p_a

--- a/rl_algo_impls/microrts/vec_env/microrts_bots.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_bots.py
@@ -1,0 +1,165 @@
+from dataclasses import astuple
+from typing import Optional
+
+import gym
+import numpy as np
+from torch.utils.tensorboard.writer import SummaryWriter
+
+from rl_algo_impls.microrts.vec_env.microrts_socket_env import MicroRTSSocketEnv
+from rl_algo_impls.microrts.vec_env.microrts_space_transform import (
+    MicroRTSSpaceTransform,
+)
+from rl_algo_impls.microrts.wrappers.microrts_stats_recorder import (
+    MicrortsStatsRecorder,
+)
+from rl_algo_impls.runner.config import Config, EnvHyperparams
+from rl_algo_impls.wrappers.action_mask_stats_recorder import ActionMaskStatsRecorder
+from rl_algo_impls.wrappers.action_mask_wrapper import MicrortsMaskWrapper
+from rl_algo_impls.wrappers.additional_win_loss_reward import (
+    AdditionalWinLossRewardWrapper,
+)
+from rl_algo_impls.wrappers.episode_stats_writer import EpisodeStatsWriter
+from rl_algo_impls.wrappers.hwc_to_chw_observation import HwcToChwObservation
+from rl_algo_impls.wrappers.is_vector_env import IsVectorEnv
+from rl_algo_impls.wrappers.score_reward_wrapper import ScoreRewardWrapper
+from rl_algo_impls.wrappers.self_play_wrapper import SelfPlayWrapper
+from rl_algo_impls.wrappers.vectorable_wrapper import VecEnv
+
+
+def make_microrts_bots_env(
+    config: Config,
+    hparams: EnvHyperparams,
+    training: bool = True,
+    render: bool = False,
+    normalize_load_path: Optional[str] = None,
+    tb_writer: Optional[SummaryWriter] = None,
+) -> VecEnv:
+    (
+        _,  # env_type
+        n_envs,
+        _,  # frame_stack
+        make_kwargs,
+        _,  # no_reward_timeout_steps
+        _,  # no_reward_fire_steps
+        _,  # vec_env_class
+        _,  # normalize
+        _,  # normalize_kwargs,
+        rolling_length,
+        _,  # train_record_video
+        _,  # video_step_interval
+        _,  # initial_steps_to_truncate
+        _,  # clip_atari_rewards
+        _,  # normalize_type
+        _,  # mask_actions
+        bots,
+        _,  # self_play_kwargs,
+        _,  # selfplay_bots,
+        additional_win_loss_reward,
+        map_paths,
+        score_reward_kwargs,
+        _,  # is_agent,
+        valid_sizes,
+        paper_planes_sizes,
+        fixed_size,
+        terrain_overrides,
+        _,  # time_budget_ms,
+        video_frames_per_second,
+        reference_bot,
+    ) = astuple(hparams)
+
+    seed = config.seed(training=training)
+
+    from rl_algo_impls.microrts import microrts_ai
+    from rl_algo_impls.microrts.vec_env.microrts_bot_vec_env import (
+        MicroRTSBotGridVecEnv,
+    )
+
+    make_kwargs = make_kwargs or {}
+    if "reward_weight" in make_kwargs:
+        # Reward Weights:
+        # RAIWinLossRewardFunction
+        # ResourceGatherRewardFunction
+        # ProduceWorkerRewardFunction
+        # ProduceBuildingRewardFunction
+        # AttackRewardFunction
+        # ProduceLightUnitRewardFunction
+        # ProduceHeavyUnitRewardFunction
+        # ProduceRangedUnitRewardFunction
+        # ScoreRewardFunction
+        make_kwargs["reward_weight"] = np.array(make_kwargs["reward_weight"])
+
+    assert bots, f"Must specify opponent bots"
+
+    assert reference_bot, f"Must specify reference_bot"
+    ref_ai = getattr(microrts_ai, reference_bot)
+    assert ref_ai, f"{reference_bot} not in microrts_ai"
+    if map_paths:
+        _map_paths = []
+        _ais = []
+        for ai_name, n in bots.items():
+            modulus = len(map_paths) * (1 if ai_name == reference_bot else 2)
+            assert (
+                n % modulus == 0
+            ), f"Expect number of {ai_name} bots ({n}) to be a multiple of {modulus}"
+            env_per_map = 2 * n // len(map_paths)
+            opp_ai = getattr(microrts_ai, ai_name)
+            for mp in map_paths:
+                _map_paths.extend([mp] * env_per_map)
+                for i in range(env_per_map // 2):
+                    _ais.extend([opp_ai, ref_ai] if i % 2 else [ref_ai, opp_ai])
+        make_kwargs["map_paths"] = _map_paths
+        make_kwargs["ais"] = _ais
+    else:
+        _ais = []
+        for ai_name, n in bots.items():
+            for i in range(n):
+                opp_ai = getattr(microrts_ai, ai_name)
+                assert opp_ai, f"{ai_name} not in microrts_ai"
+                _ais.extend([opp_ai, ref_ai] if i % 2 else [ref_ai, opp_ai])
+        make_kwargs["ais"] = _ais
+    make_kwargs["reference_indexes"] = [
+        idx for idx, ai in enumerate(make_kwargs["ais"]) if ai == ref_ai
+    ]
+
+    envs = MicroRTSBotGridVecEnv(
+        **make_kwargs, video_frames_per_second=video_frames_per_second
+    )
+
+    envs = MicroRTSSpaceTransform(
+        envs,
+        valid_sizes=valid_sizes,
+        paper_planes_sizes=paper_planes_sizes,
+        fixed_size=fixed_size,
+        terrain_overrides=terrain_overrides,
+    )
+    envs = HwcToChwObservation(envs)
+    envs = IsVectorEnv(envs)
+    envs = MicrortsMaskWrapper(envs)
+
+    if seed is not None:
+        envs.action_space.seed(seed)
+        envs.observation_space.seed(seed)
+
+    envs = gym.wrappers.RecordEpisodeStatistics(envs)
+    envs = MicrortsStatsRecorder(
+        envs,
+        bots,
+        make_kwargs.get("map_paths"),
+    )
+    envs = ActionMaskStatsRecorder(envs)
+    if training:
+        assert tb_writer
+        envs = EpisodeStatsWriter(
+            envs,
+            tb_writer,
+            training=training,
+            rolling_length=rolling_length,
+            additional_keys_to_log=config.additional_keys_to_log,
+        )
+
+    if additional_win_loss_reward:
+        envs = AdditionalWinLossRewardWrapper(envs)
+    if score_reward_kwargs:
+        envs = ScoreRewardWrapper(envs, **score_reward_kwargs)
+
+    return envs

--- a/rl_algo_impls/microrts/vec_env/microrts_interface.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_interface.py
@@ -87,6 +87,10 @@ class MicroRTSInterface(ABC):
     def set_expected_step_ms(self, expected_step_ms: int) -> None:
         pass
 
+    @property
+    def last_action(self) -> Optional[List[List[List[int]]]]:
+        return None
+
     @abstractmethod
     def close(self, **kwargs):
         ...

--- a/rl_algo_impls/microrts/vec_env/microrts_vec_env.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_vec_env.py
@@ -39,13 +39,6 @@ UTT_VERSION_ORIGINAL_FINETUNED = 2
 
 class MicroRTSGridModeVecEnv(MicroRTSInterface):
     DEBUG_VERIFY = False
-    """
-    [[0]x_coordinate*y_coordinate(x*y), [1]a_t(6), [2]p_move(4), [3]p_harvest(4), 
-    [4]p_return(4), [5]p_produce_direction(4), [6]p_produce_unit_type(z), 
-    [7]x_coordinate*y_coordinate(x*y)]
-    Create a baselines VecEnv environment from a gym3 environment.
-    :param env: gym3 environment to adapt
-    """
 
     def __init__(
         self,

--- a/rl_algo_impls/microrts/wrappers/microrts_stats_recorder.py
+++ b/rl_algo_impls/microrts/wrappers/microrts_stats_recorder.py
@@ -13,12 +13,10 @@ class MicrortsStatsRecorder(VectorableWrapper):
     def __init__(
         self,
         env,
-        gamma: float,
         bots: Optional[Dict[str, int]] = None,
         map_paths: Optional[List[str]] = None,
     ) -> None:
         super().__init__(env)
-        self.gamma = gamma
         self.raw_rewards = [[] for _ in range(self.num_envs)]
         self.bots = bots
         if self.bots:

--- a/rl_algo_impls/ppo/ppo.py
+++ b/rl_algo_impls/ppo/ppo.py
@@ -241,7 +241,7 @@ class PPO(Algorithm):
                     logratio = new_logprobs - mb_logprobs
                     ratio = torch.exp(logratio)
                     clipped_ratio = torch.clamp(ratio, min=1 - pi_clip, max=1 + pi_clip)
-                    pi_loss = torch.max(-ratio * mb_adv, -clipped_ratio * mb_adv).mean()
+                    pi_loss = -torch.min(ratio * mb_adv, clipped_ratio * mb_adv).mean()
 
                     v_loss_unclipped = (new_values - mb_returns) ** 2
                     if v_clip:

--- a/rl_algo_impls/ppo/ppo.py
+++ b/rl_algo_impls/ppo/ppo.py
@@ -224,6 +224,7 @@ class PPO(Algorithm):
                         mb_logprobs,
                         mb_actions,
                         mb_action_masks,
+                        mb_num_actions,
                         mb_values,
                         mb_adv,
                         mb_returns,
@@ -243,9 +244,9 @@ class PPO(Algorithm):
                     clipped_ratio = torch.clamp(ratio, min=1 - pi_clip, max=1 + pi_clip)
                     pi_loss = -torch.min(ratio * mb_adv, clipped_ratio * mb_adv)
                     if self.scale_loss_by_num_actions:
-                        with torch.no_grad():
-                            num_actions = mb_action_masks.any(2).sum(1)
-                        pi_loss = torch.where(num_actions > 0, pi_loss / num_actions, 0)
+                        pi_loss = torch.where(
+                            mb_num_actions > 0, pi_loss / mb_num_actions, 0
+                        )
                     pi_loss = pi_loss.mean()
 
                     v_loss_unclipped = (new_values - mb_returns) ** 2

--- a/rl_algo_impls/ppo/ppo.py
+++ b/rl_algo_impls/ppo/ppo.py
@@ -20,12 +20,7 @@ from rl_algo_impls.shared.schedule import (
     update_learning_rate,
 )
 from rl_algo_impls.shared.stats import log_scalars
-from rl_algo_impls.shared.tensor_utils import (
-    NumOrList,
-    num_or_array,
-    unqueeze_dims_to_match,
-)
-from rl_algo_impls.wrappers.vectorable_wrapper import VecEnv
+from rl_algo_impls.shared.tensor_utils import NumOrList, num_or_array
 
 
 class TrainStepStats(NamedTuple):

--- a/rl_algo_impls/ppo/reference_ai_rollout.py
+++ b/rl_algo_impls/ppo/reference_ai_rollout.py
@@ -1,0 +1,79 @@
+import logging
+
+import numpy as np
+import torch
+
+from rl_algo_impls.ppo.rollout import Rollout
+from rl_algo_impls.ppo.sync_step_rollout import SyncStepRolloutGenerator, fold_in
+from rl_algo_impls.shared.policy.actor_critic import ActorCritic
+from rl_algo_impls.shared.tensor_utils import NumpyOrDict, TensorOrDict, tensor_to_numpy
+from rl_algo_impls.wrappers.vectorable_wrapper import VecEnv
+
+
+class ReferenceAIRollout(SyncStepRolloutGenerator):
+    def __init__(
+        self,
+        training_policy: ActorCritic,
+        reference_vec_env: VecEnv,
+        n_steps: int = 2048,
+        sde_sample_freq: int = -1,
+    ) -> None:
+        super().__init__(training_policy, reference_vec_env, n_steps, sde_sample_freq)
+        if isinstance(self.actions, dict):
+            self.zero_action = {k: np.zeros_like(v[0]) for k, v in self.actions.items()}
+        else:
+            self.zero_action = np.zeros_like(self.actions[0])
+
+    def rollout(self) -> Rollout:
+        self.policy.eval()
+        self.policy.reset_noise()
+        for s in range(self.n_steps):
+            if self.sde_sample_freq > 0 and s > 0 and s % self.sde_sample_freq == 0:
+                self.policy.reset_noise()
+
+            self.obs[s] = self.next_obs
+            self.episode_starts[s] = self.next_episode_starts
+            if self.action_masks is not None:
+                fold_in(self.action_masks, self.next_action_masks, s)
+
+            t_obs = torch.as_tensor(self.next_obs).to(self.policy.device)
+            t_action_masks = self.actions_to_tensor(self.next_action_masks)
+            (
+                self.next_obs,
+                self.rewards[s],
+                self.next_episode_starts,
+                _,
+            ) = self.vec_env.step(self.zero_action)
+            actions = getattr(self.vec_env, "last_action")
+            fold_in(self.actions, actions, s)
+
+            t_actions = self.actions_to_tensor(actions)
+            with torch.no_grad():
+                (logprobs, _, values) = self.policy(
+                    t_obs, t_actions, action_masks=t_action_masks
+                )
+            self.logprobs[s] = tensor_to_numpy(logprobs)
+            self.values[s] = tensor_to_numpy(values)
+
+            self.next_action_masks = (
+                self.get_action_mask() if self.get_action_mask else None
+            )
+
+        self.policy.train()
+        assert isinstance(self.next_obs, np.ndarray)
+        return Rollout(
+            next_obs=self.next_obs,
+            next_episode_starts=self.next_episode_starts,
+            obs=self.obs,
+            actions=self.actions,
+            rewards=self.rewards,
+            episode_starts=self.episode_starts,
+            values=self.values,
+            logprobs=self.logprobs,
+            action_masks=self.action_masks,
+        )
+
+    def actions_to_tensor(self, a: NumpyOrDict) -> TensorOrDict:
+        if isinstance(a, dict):
+            return {k: torch.as_tensor(v).to(self.policy.device) for k, v in a.items()}
+        return torch.as_tensor(a).to(self.policy.device)

--- a/rl_algo_impls/ppo/reference_ai_rollout.py
+++ b/rl_algo_impls/ppo/reference_ai_rollout.py
@@ -17,8 +17,15 @@ class ReferenceAIRollout(SyncStepRolloutGenerator):
         reference_vec_env: VecEnv,
         n_steps: int = 2048,
         sde_sample_freq: int = -1,
+        scale_advantage_by_values_accuracy: bool = False,
     ) -> None:
-        super().__init__(training_policy, reference_vec_env, n_steps, sde_sample_freq)
+        super().__init__(
+            training_policy,
+            reference_vec_env,
+            n_steps,
+            sde_sample_freq,
+            scale_advantage_by_values_accuracy=scale_advantage_by_values_accuracy,
+        )
         if isinstance(self.actions, dict):
             self.zero_action = {k: np.zeros_like(v[0]) for k, v in self.actions.items()}
         else:
@@ -71,6 +78,7 @@ class ReferenceAIRollout(SyncStepRolloutGenerator):
             values=self.values,
             logprobs=self.logprobs,
             action_masks=self.action_masks,
+            scale_advantage_by_values_accuracy=self.scale_advantage_by_values_accuracy,
         )
 
     def actions_to_tensor(self, a: NumpyOrDict) -> TensorOrDict:

--- a/rl_algo_impls/ppo/sync_step_rollout.py
+++ b/rl_algo_impls/ppo/sync_step_rollout.py
@@ -1,7 +1,6 @@
 from typing import Dict, TypeVar
 
 import numpy as np
-from gym.spaces import Dict as DictSpace
 
 from rl_algo_impls.ppo.rollout import Rollout, RolloutGenerator
 from rl_algo_impls.shared.policy.actor_critic import ActorCritic

--- a/rl_algo_impls/ppo/sync_step_rollout.py
+++ b/rl_algo_impls/ppo/sync_step_rollout.py
@@ -19,8 +19,13 @@ class SyncStepRolloutGenerator(RolloutGenerator):
         vec_env: VecEnv,
         n_steps: int = 2048,
         sde_sample_freq: int = -1,
+        scale_advantage_by_values_accuracy: bool = False,
     ) -> None:
-        super().__init__(n_steps, sde_sample_freq)
+        super().__init__(
+            n_steps,
+            sde_sample_freq,
+            scale_advantage_by_values_accuracy=scale_advantage_by_values_accuracy,
+        )
         self.policy = policy
         self.vec_env = vec_env
         self.get_action_mask = getattr(vec_env, "get_action_mask", None)
@@ -115,6 +120,7 @@ class SyncStepRolloutGenerator(RolloutGenerator):
             values=self.values,
             logprobs=self.logprobs,
             action_masks=self.action_masks,
+            scale_advantage_by_values_accuracy=self.scale_advantage_by_values_accuracy,
         )
 
 

--- a/rl_algo_impls/runner/config.py
+++ b/rl_algo_impls/runner/config.py
@@ -63,6 +63,7 @@ class EnvHyperparams:
     terrain_overrides: Optional[Dict[str, Any]] = None
     time_budget_ms: Optional[int] = None
     video_frames_per_second: Optional[int] = None
+    reference_bot: Optional[str] = None
 
 
 HyperparamsSelf = TypeVar("HyperparamsSelf", bound="Hyperparams")
@@ -86,6 +87,7 @@ class Hyperparams:
         default_factory=dict
     )
     rollout_hyperparams: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    rollout_type: Optional[str] = None
 
     @classmethod
     def from_dict_with_extra_fields(
@@ -136,6 +138,10 @@ class Config:
     @property
     def rollout_hyperparams(self) -> Dict[str, Any]:
         return self.hyperparams.rollout_hyperparams
+
+    @property
+    def rollout_type(self) -> Optional[str]:
+        return self.hyperparams.rollout_type
 
     def eval_callback_params(self) -> Dict[str, Any]:
         eval_hyperparams = self.eval_hyperparams.copy()

--- a/rl_algo_impls/runner/running_utils.py
+++ b/rl_algo_impls/runner/running_utils.py
@@ -17,6 +17,7 @@ from gym.spaces import Box, Discrete
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from rl_algo_impls.a2c.a2c import A2C
+from rl_algo_impls.acbc.acbc import ACBC
 from rl_algo_impls.dqn.dqn import DQN
 from rl_algo_impls.dqn.policy import DQNPolicy
 from rl_algo_impls.ppo.ppo import PPO
@@ -36,12 +37,14 @@ ALGOS: Dict[str, Type[Algorithm]] = {
     "vpg": VanillaPolicyGradient,
     "ppo": PPO,
     "a2c": A2C,
+    "acbc": ACBC,
 }
 POLICIES: Dict[str, Type[Policy]] = {
     "dqn": DQNPolicy,
     "vpg": VPGActorCritic,
     "ppo": ActorCritic,
     "a2c": ActorCritic,
+    "acbc": ActorCritic,
 }
 
 HYPERPARAMS_PATH = "hyperparams"

--- a/rl_algo_impls/runner/train.py
+++ b/rl_algo_impls/runner/train.py
@@ -1,6 +1,7 @@
 # Support for PyTorch mps mode (https://pytorch.org/docs/stable/notes/mps.html)
 import os
 
+from rl_algo_impls.ppo.reference_ai_rollout import ReferenceAIRollout
 from rl_algo_impls.ppo.sync_step_rollout import SyncStepRolloutGenerator
 from rl_algo_impls.shared.callbacks.self_play_callback import SelfPlayCallback
 
@@ -133,9 +134,14 @@ def train(args: TrainArgs):
     if self_play_wrapper:
         callbacks.append(SelfPlayCallback(policy, policy_factory, self_play_wrapper))
 
-    rollout_generator = SyncStepRolloutGenerator(
-        policy, env, **config.rollout_hyperparams
-    )
+    rollout_generator_cls = SyncStepRolloutGenerator
+    if config.rollout_type:
+        if config.rollout_type == "reference":
+            rollout_generator_cls = ReferenceAIRollout
+        else:
+            raise ValueError(f"{config.rollout_type} not recognized rollout_type")
+
+    rollout_generator = rollout_generator_cls(policy, env, **config.rollout_hyperparams)
     algo.learn(config.n_timesteps, rollout_generator, callbacks=callbacks)
 
     policy.save(config.model_dir_path(best=False))

--- a/rl_algo_impls/shared/callbacks/eval_callback.py
+++ b/rl_algo_impls/shared/callbacks/eval_callback.py
@@ -171,7 +171,7 @@ class EvalCallback(Callback):
         desired_num_stats = self.timesteps_elapsed // self.step_freq
         if not self.skip_evaluate_at_start:
             desired_num_stats += 1
-        if desired_num_stats >= len(self.stats):
+        if desired_num_stats > len(self.stats):
             self.evaluate()
         return True
 

--- a/rl_algo_impls/shared/callbacks/eval_callback.py
+++ b/rl_algo_impls/shared/callbacks/eval_callback.py
@@ -138,6 +138,7 @@ class EvalCallback(Callback):
         score_function: str = "mean-std",
         wandb_enabled: bool = False,
         score_threshold: Optional[float] = None,
+        skip_evaluate_at_start: bool = False,
     ) -> None:
         super().__init__()
         self.policy = policy
@@ -163,10 +164,14 @@ class EvalCallback(Callback):
         self.score_function = score_function
         self.wandb_enabled = wandb_enabled
         self.score_threshold = score_threshold
+        self.skip_evaluate_at_start = skip_evaluate_at_start
 
     def on_step(self, timesteps_elapsed: int = 1) -> bool:
         super().on_step(timesteps_elapsed)
-        if self.timesteps_elapsed // self.step_freq >= len(self.stats):
+        desired_num_stats = self.timesteps_elapsed // self.step_freq
+        if not self.skip_evaluate_at_start:
+            desired_num_stats += 1
+        if desired_num_stats >= len(self.stats):
             self.evaluate()
         return True
 

--- a/rl_algo_impls/shared/gae.py
+++ b/rl_algo_impls/shared/gae.py
@@ -72,13 +72,34 @@ def compute_rtg_and_advantage_from_trajectories(
     )
 
 
-def compute_advantages(
+def compute_advantages_from_policy(
     rewards: np.ndarray,
     values: np.ndarray,
     episode_starts: np.ndarray,
     next_episode_starts: np.ndarray,
     next_obs: VecEnvObs,
     policy: OnPolicy,
+    gamma: Union[float, np.ndarray],
+    gae_lambda: Union[float, np.ndarray],
+) -> np.ndarray:
+    next_values = policy.value(next_obs)
+    return compute_advantages(
+        rewards,
+        values,
+        episode_starts,
+        next_episode_starts,
+        next_values,
+        gamma,
+        gae_lambda,
+    )
+
+
+def compute_advantages(
+    rewards: np.ndarray,
+    values: np.ndarray,
+    episode_starts: np.ndarray,
+    next_episode_starts: np.ndarray,
+    next_values: np.ndarray,
     gamma: Union[float, np.ndarray],
     gae_lambda: Union[float, np.ndarray],
 ) -> np.ndarray:
@@ -92,7 +113,7 @@ def compute_advantages(
     for t in reversed(range(n_steps)):
         if t == n_steps - 1:
             next_nonterminal = 1.0 - next_episode_starts
-            next_value = policy.value(next_obs)
+            next_value = next_values
         else:
             next_nonterminal = 1.0 - episode_starts[t + 1]
             next_value = values[t + 1]

--- a/rl_algo_impls/shared/policy/actor_critic.py
+++ b/rl_algo_impls/shared/policy/actor_critic.py
@@ -130,6 +130,7 @@ class ActorCritic(OnPolicy):
         decoder_residual_blocks_per_level: Optional[List[int]] = None,
         increment_kernel_size_on_down_conv: bool = False,
         output_activation_fn: str = "identity",
+        subaction_mask: Optional[List[int]] = None,
         **kwargs,
     ) -> None:
         super().__init__(env, **kwargs)
@@ -189,6 +190,7 @@ class ActorCritic(OnPolicy):
                 decoder_residual_blocks_per_level=decoder_residual_blocks_per_level,
                 increment_kernel_size_on_down_conv=increment_kernel_size_on_down_conv,
                 output_activation_fn=output_activation_fn,
+                subaction_mask=subaction_mask,
             )
         elif share_features_extractor:
             self.network = ConnectedTrioActorCriticNetwork(

--- a/rl_algo_impls/shared/policy/actor_critic.py
+++ b/rl_algo_impls/shared/policy/actor_critic.py
@@ -129,6 +129,7 @@ class ActorCritic(OnPolicy):
         encoder_residual_blocks_per_level: Optional[List[int]] = None,
         decoder_residual_blocks_per_level: Optional[List[int]] = None,
         increment_kernel_size_on_down_conv: bool = False,
+        output_activation_fn: str = "identity",
         **kwargs,
     ) -> None:
         super().__init__(env, **kwargs)
@@ -187,6 +188,7 @@ class ActorCritic(OnPolicy):
                 encoder_residual_blocks_per_level=encoder_residual_blocks_per_level,
                 decoder_residual_blocks_per_level=decoder_residual_blocks_per_level,
                 increment_kernel_size_on_down_conv=increment_kernel_size_on_down_conv,
+                output_activation_fn=output_activation_fn,
             )
         elif share_features_extractor:
             self.network = ConnectedTrioActorCriticNetwork(

--- a/rl_algo_impls/shared/policy/actor_critic_network/backbone_actor_critic.py
+++ b/rl_algo_impls/shared/policy/actor_critic_network/backbone_actor_critic.py
@@ -33,6 +33,7 @@ class BackboneActorCritic(ActorCriticNetwork):
         init_layers_orthogonal: bool = True,
         cnn_layers_init_orthogonal: bool = False,
         strides: Sequence[Union[int, Sequence[int]]] = (2, 2),
+        output_activation_fn: str = "identity",
     ):
         if num_additional_critics and not additional_critic_activation_functions:
             additional_critic_activation_functions = [
@@ -131,7 +132,7 @@ class BackboneActorCritic(ActorCriticNetwork):
         self.critic_heads = HStack(
             [
                 critic_head(act_fn_name)
-                for act_fn_name in ["identity"]
+                for act_fn_name in [output_activation_fn]
                 + (additional_critic_activation_functions or [])
             ]
         )

--- a/rl_algo_impls/shared/policy/actor_critic_network/backbone_actor_critic.py
+++ b/rl_algo_impls/shared/policy/actor_critic_network/backbone_actor_critic.py
@@ -160,7 +160,7 @@ class BackboneActorCritic(ActorCriticNetwork):
 
         v = self.critic_heads(x)
         if v.shape[-1] == 1:
-            v.squeeze(-1)
+            v = v.squeeze(-1)
 
         return ACNForward(pi_forward(pi, action), v)
 
@@ -169,7 +169,7 @@ class BackboneActorCritic(ActorCriticNetwork):
         x = self.backbone(o)
         v = self.critic_heads(x)
         if v.shape[-1] == 1:
-            v.squeeze(-1)
+            v = v.squeeze(-1)
         return v
 
     def reset_noise(self, batch_size: Optional[int] = None) -> None:

--- a/rl_algo_impls/shared/policy/actor_critic_network/backbone_actor_critic.py
+++ b/rl_algo_impls/shared/policy/actor_critic_network/backbone_actor_critic.py
@@ -34,6 +34,7 @@ class BackboneActorCritic(ActorCriticNetwork):
         cnn_layers_init_orthogonal: bool = False,
         strides: Sequence[Union[int, Sequence[int]]] = (2, 2),
         output_activation_fn: str = "identity",
+        subaction_mask: Optional[List[int]] = None,
     ):
         if num_additional_critics and not additional_critic_activation_functions:
             additional_critic_activation_functions = [
@@ -57,6 +58,7 @@ class BackboneActorCritic(ActorCriticNetwork):
             raise ValueError(
                 f"action_space {action_space.__class__.__name__} must be MultiDiscrete or gym Dict of MultiDiscrete"
             )
+        self.subaction_mask = subaction_mask
 
         self.map_size = len(action_space_per_position.nvec) // len(action_plane_space.nvec)  # type: ignore
 
@@ -156,7 +158,13 @@ class BackboneActorCritic(ActorCriticNetwork):
         x = self.backbone(o)
         logits = self.actor_head(x)
         pi = GridnetDistribution(
-            int(np.prod(o.shape[-2:])), self.action_vec, logits, action_masks
+            int(np.prod(o.shape[-2:])),
+            self.action_vec,
+            logits,
+            action_masks,
+            subaction_mask=torch.tensor(self.subaction_mask).to(obs.device)
+            if self.subaction_mask
+            else None,
         )
 
         v = self.critic_heads(x)

--- a/rl_algo_impls/shared/policy/actor_critic_network/squeeze_unet.py
+++ b/rl_algo_impls/shared/policy/actor_critic_network/squeeze_unet.py
@@ -198,6 +198,7 @@ class SqueezeUnetActorCriticNetwork(BackboneActorCritic):
         critic_channels: int = 64,
         increment_kernel_size_on_down_conv: bool = False,
         output_activation_fn: str = "identity",
+        subaction_mask: Optional[List[int]] = None,
     ) -> None:
         if cnn_layers_init_orthogonal is None:
             cnn_layers_init_orthogonal = False
@@ -241,4 +242,5 @@ class SqueezeUnetActorCriticNetwork(BackboneActorCritic):
             cnn_layers_init_orthogonal=cnn_layers_init_orthogonal,
             strides=strides_per_level,
             output_activation_fn=output_activation_fn,
+            subaction_mask=subaction_mask,
         )

--- a/rl_algo_impls/shared/policy/actor_critic_network/squeeze_unet.py
+++ b/rl_algo_impls/shared/policy/actor_critic_network/squeeze_unet.py
@@ -197,6 +197,7 @@ class SqueezeUnetActorCriticNetwork(BackboneActorCritic):
         additional_critic_activation_functions: Optional[List[str]] = None,
         critic_channels: int = 64,
         increment_kernel_size_on_down_conv: bool = False,
+        output_activation_fn: str = "identity",
     ) -> None:
         if cnn_layers_init_orthogonal is None:
             cnn_layers_init_orthogonal = False
@@ -239,4 +240,5 @@ class SqueezeUnetActorCriticNetwork(BackboneActorCritic):
             init_layers_orthogonal=init_layers_orthogonal,
             cnn_layers_init_orthogonal=cnn_layers_init_orthogonal,
             strides=strides_per_level,
+            output_activation_fn=output_activation_fn,
         )

--- a/rl_algo_impls/shared/vec_env/make_env.py
+++ b/rl_algo_impls/shared/vec_env/make_env.py
@@ -27,6 +27,10 @@ def make_env(
         from rl_algo_impls.microrts.vec_env.microrts import make_microrts_env
 
         make_env_fn = make_microrts_env
+    elif hparams.env_type == "microrts_bots":
+        from rl_algo_impls.microrts.vec_env.microrts_bots import make_microrts_bots_env
+
+        make_env_fn = make_microrts_bots_env
     elif hparams.env_type == "lux":
         from rl_algo_impls.lux.vec_env.lux import make_lux_env
 

--- a/rl_algo_impls/shared/vec_env/procgen.py
+++ b/rl_algo_impls/shared/vec_env/procgen.py
@@ -47,12 +47,13 @@ def make_procgen_env(
         _,  # map_paths,
         _,  # score_reward_kwargs,
         _,  # is_agent
-        _, # valid_sizes,
-        _, # paper_planes_sizes,
-        _, # fixed_size,
-        _, # terrain_overrides,
+        _,  # valid_sizes,
+        _,  # paper_planes_sizes,
+        _,  # fixed_size,
+        _,  # terrain_overrides,
         _,  # time_budget_ms,
         _,  # video_frames_per_second,
+        _,  # reference_bot,
     ) = astuple(hparams)
 
     seed = config.seed(training=training)

--- a/rl_algo_impls/shared/vec_env/vec_env.py
+++ b/rl_algo_impls/shared/vec_env/vec_env.py
@@ -87,6 +87,7 @@ def make_vec_env(
         _,  # terrain_overrides,
         _,  # time_budget_ms,
         _,  # video_frames_per_second,
+        _,  # reference_bot,
     ) = astuple(hparams)
 
     import_for_env_id(config.env_id)

--- a/rl_algo_impls/wrappers/action_mask_stats_recorder.py
+++ b/rl_algo_impls/wrappers/action_mask_stats_recorder.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from gym import Env
+
+from rl_algo_impls.wrappers.vectorable_wrapper import (
+    VecEnvObs,
+    VecEnvStepReturn,
+    VectorableWrapper,
+)
+
+
+class ActionMaskStatsRecorder(VectorableWrapper):
+    def __init__(self, env) -> None:
+        super().__init__(env)
+        self.get_action_mask = getattr(env, "get_action_mask")
+
+    def reset(self) -> VecEnvObs:
+        obs = super().reset()
+        self.episode_num_valid_locations = np.zeros(self.num_envs, dtype=np.int32)
+        self.episode_no_valid_actions = np.zeros(self.num_envs, dtype=np.int32)
+        self.episode_lengths = np.zeros(self.num_envs, dtype=np.int32)
+        return obs
+
+    def step(self, actions) -> VecEnvStepReturn:
+        obs, rews, dones, infos = super().step(actions)
+
+        action_mask = self.get_action_mask()
+        num_valid_locations = np.sum(np.any(action_mask, axis=2), axis=1)
+        self.episode_num_valid_locations += num_valid_locations
+        self.episode_no_valid_actions += num_valid_locations == 0
+        self.episode_lengths += 1
+
+        for idx, (info, done) in enumerate(zip(infos, dones)):
+            if done:
+                info["action_mask_stats"] = {
+                    "valid_locs": self.episode_num_valid_locations[idx]
+                    / self.episode_lengths[idx],
+                    "no_valid": self.episode_no_valid_actions[idx]
+                    / self.episode_lengths[idx],
+                }
+                self.episode_num_valid_locations[idx] = 0
+                self.episode_no_valid_actions[idx] = 0
+                self.episode_lengths[idx] = 0
+
+        return obs, rews, dones, infos


### PR DESCRIPTION
This original branch was for a form of offline PPO; however, I couldn't get it to learn stably. The closest implemented version of what I wanted was BPPO (https://github.com/Dragon-Zhuang/BPPO), which did behavior cloning to bootstrap the policy and critic. ACBC (Actor-critic Behavior Cloning) is my implementation of behavior cloning that trains the actor and critic heads simultaneously.

ACBC was still unstable until I scaled the policy loss by the number of available positions to move. This scaling helped BPPO train without diverging, but OPPO is still unstable. Next steps is to train OPPO and PPO with the best ACBC-trained model so far.