### PR TITLE
Migrate to the new render API of Gymnasium 

### DIFF
--- a/rl_algo_impls/microrts/vec_env/microrts_bot_vec_env.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_bot_vec_env.py
@@ -56,6 +56,7 @@ class MicroRTSBotGridVecEnv(MicroRTSInterface):
         cycle_maps=[],
         video_frames_per_second: Optional[int] = None,
         non_deterministic: bool = False,
+        render_mode: Optional[str] = None,
     ):
         self._num_envs = len(reference_indexes)
         self._partial_obs = partial_obs
@@ -79,6 +80,7 @@ class MicroRTSBotGridVecEnv(MicroRTSInterface):
             if video_frames_per_second is not None
             else 150,
         }
+        self.render_mode = "rgb_array" if render_mode is None else render_mode
 
         self.microrts_path = os.path.join(Path(__file__).parent.parent, "java")
 
@@ -313,13 +315,13 @@ class MicroRTSBotGridVecEnv(MicroRTSInterface):
     def last_action(self) -> List[List[List[int]]]:
         return select(self._action, self.reference_indexes)
 
-    def render(self, mode="human"):
-        if mode == "human":
+    def render(self):
+        if self.render_mode == "human":
             self.render_client.render(False)
             # give warning on macos because the render is not available
             if sys.platform == "darwin":
                 warnings.warn(MICRORTS_MAC_OS_RENDER_MESSAGE)
-        elif mode == "rgb_array":
+        elif self.render_mode == "rgb_array":
             bytes_array = np.array(self.render_client.render(True))
             image = Image.frombytes("RGB", (640, 640), bytes_array)
             return np.array(image)[:, :, ::-1]

--- a/rl_algo_impls/microrts/vec_env/microrts_bot_vec_env.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_bot_vec_env.py
@@ -56,7 +56,7 @@ class MicroRTSBotGridVecEnv(MicroRTSInterface):
         cycle_maps=[],
         video_frames_per_second: Optional[int] = None,
         non_deterministic: bool = False,
-        render_mode: Optional[str] = None,
+        render_mode: str = "rgb_array",
     ):
         self._num_envs = len(reference_indexes)
         self._partial_obs = partial_obs
@@ -80,7 +80,7 @@ class MicroRTSBotGridVecEnv(MicroRTSInterface):
             if video_frames_per_second is not None
             else 150,
         }
-        self.render_mode = "rgb_array" if render_mode is None else render_mode
+        self.render_mode = render_mode
 
         self.microrts_path = os.path.join(Path(__file__).parent.parent, "java")
 

--- a/rl_algo_impls/microrts/vec_env/microrts_space_transform.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_space_transform.py
@@ -268,8 +268,8 @@ class MicroRTSSpaceTransform(VectorEnv, MicroRTSInterfaceListener):
         self._update_action_mask(microrts_mask)
         return self._from_microrts_obs(microrts_obs), {}
 
-    def render(self, mode="human"):
-        return self.interface.render(mode)
+    def render(self):
+        return self.interface.render()
 
     def close_extras(self, **kwargs):
         if not self.fixed_size:

--- a/rl_algo_impls/microrts/vec_env/microrts_vec_env.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_vec_env.py
@@ -54,7 +54,7 @@ class MicroRTSGridModeVecEnv(MicroRTSInterface):
         cycle_maps=[],
         bot_envs_alternate_player: bool = False,
         video_frames_per_second: Optional[int] = None,
-        render_mode: Optional[str] = None,
+        render_mode: str = "rgb_array",
     ):
         self.num_selfplay_envs = num_selfplay_envs
         self.num_bot_envs = num_bot_envs
@@ -83,7 +83,7 @@ class MicroRTSGridModeVecEnv(MicroRTSInterface):
             if video_frames_per_second is not None
             else 150,
         }
-        self.render_mode = "rgb_array" if render_mode is None else render_mode
+        self.render_mode = render_mode
 
         self.microrts_path = os.path.join(Path(__file__).parent.parent, "java")
 

--- a/rl_algo_impls/microrts/vec_env/microrts_vec_env.py
+++ b/rl_algo_impls/microrts/vec_env/microrts_vec_env.py
@@ -54,6 +54,7 @@ class MicroRTSGridModeVecEnv(MicroRTSInterface):
         cycle_maps=[],
         bot_envs_alternate_player: bool = False,
         video_frames_per_second: Optional[int] = None,
+        render_mode: Optional[str] = None,
     ):
         self.num_selfplay_envs = num_selfplay_envs
         self.num_bot_envs = num_bot_envs
@@ -82,6 +83,7 @@ class MicroRTSGridModeVecEnv(MicroRTSInterface):
             if video_frames_per_second is not None
             else 150,
         }
+        self.render_mode = "rgb_array" if render_mode is None else render_mode
 
         self.microrts_path = os.path.join(Path(__file__).parent.parent, "java")
 
@@ -335,13 +337,13 @@ class MicroRTSGridModeVecEnv(MicroRTSInterface):
     def resources(self, env_idx: int) -> np.ndarray:
         return self._resources[env_idx]
 
-    def render(self, mode="human"):
-        if mode == "human":
+    def render(self):
+        if self.render_mode == "human":
             self.render_client.render(False)
             # give warning on macos because the render is not available
             if sys.platform == "darwin":
                 warnings.warn(MICRORTS_MAC_OS_RENDER_MESSAGE)
-        elif mode == "rgb_array":
+        elif self.render_mode == "rgb_array":
             bytes_array = np.array(self.render_client.render(True))
             image = Image.frombytes("RGB", (640, 640), bytes_array)
             return np.array(image)[:, :, ::-1]


### PR DESCRIPTION
Gymnasium v26+ introduced a change to the render API. This PR apply the changes as suggested in [the migration note](https://younis.dev/blog/render-api/).

Since Gymnasium will be the primary caller for these render functions, I changed the default `render_mode` from `"human"` to `"rgb_array"`.